### PR TITLE
Fix "header must not contain Status" Rack::Lint::LintError.

### DIFF
--- a/tdiary/dispatcher.rb
+++ b/tdiary/dispatcher.rb
@@ -234,6 +234,7 @@ module TDiary
 			begin
 				$stdout = raw_result; $stderr = dummy_stderr
 				result = @target.run( cgi )
+				result.headers.reject!{|k,v| k.to_s.downcase == "status" }
 				result.to_a
 			ensure
 				$stdout = stdout_orig


### PR DESCRIPTION
Ruby 1.9.2 と Rack 1.2.1 でローカルで動かしたらupdate.rb でRack::Lint::LintErrorが
出たので、とりいそぎ "status"ヘッダを削除したら動くようになりました。

自分の環境だけの問題なのかな……。
