### PR TITLE
diary/lang/en.rb: add utf-8 option on regexp.

### DIFF
--- a/tdiary/lang/en.rb
+++ b/tdiary/lang/en.rb
@@ -63,7 +63,7 @@ end
 # 'shorten' method cuts string length.
 # 
 def shorten( str, length = 120 )
-	matched = str.gsub( /\n/, ' ' ).scan( /^.{0,#{length - 2}}/ )[0]
+	matched = str.gsub( /\n/, ' ' ).scan( /^.{0,#{length - 2}}/u )[0]
 	unless $'.empty?
 		matched + '..'
 	else


### PR DESCRIPTION
英語UIで日本語の日記を書いているとき(具体的にはRubyKaigi日記なのですが)、
フィードのdescriptionの文字の切れ目がおかしくなってしまうケースがあります。
http://rubykaigi.tdiary.net/index.rdf

lang/ja.rb は正規表現にuオプションがついてますが、lang/en.rb にもそれを付けてほしいです。

> > Generated by tDiary version 3.0.1.20110403, Powered by Ruby version 1.8.2(えっ)
