### PR TITLE
圧縮版のjQuery (jquery.min.js) を読み込むようにしてほしい

### DIFF
--- a/plugin/00default.rb
+++ b/plugin/00default.rb
@@ -353,7 +353,7 @@ def description_tag
 end
 
 def jquery_tag
-	%Q[<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.5/jquery.js" type="text/javascript"></script>]
+	%Q[<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.5/jquery.min.js" type="text/javascript"></script>]
 end
 
 enable_js( '00default.js' )


### PR DESCRIPTION
表示速度の改善のため、jquery.jsの代わりにjquery.min.jsを読み込むようにしてほしいです。

なお、 issuesの #43 で少し議論していますが、開発環境で非圧縮版のjquery.jsを読み込むためのプラグインをcontribに追加しています。
https://github.com/tdiary/tdiary-contrib/commit/462806f90ade2fc0a55e66c8280d1b77e2c8f943
