### PR TITLE
highlight.js: fixed XSS vulnerability

### DIFF
--- a/js/highlight.js
+++ b/js/highlight.js
@@ -24,9 +24,6 @@ $(function() {
     })
 
   if (document.location.hash) {
-    var anchor_name = document.location.hash.substr(1);
-    if (anchor_name.match(/^[pc][0-9]{2}$/)) {
-      highlight($('[name=' + anchor_name + ']')[0]);
-    }
+    highlight($('[name=' + document.location.hash.replace(/[^\w]/g, "") + ']')[0]);
   }
 });


### PR DESCRIPTION
highlight.jsはlocation.hashの値をjQueryのセレクタとして渡しているため、以下の問題の影響を受けます。

[jQueryにおけるXSSを引き起こしやすい問題について](http://subtech.g.hatena.ne.jp/mala/20110624/1308881526)

対策として、$()関数に渡す前にlocation.hashの値が期待されるアンカーであることのチェックを行うように修正しました。
以下の正規表現で #p00~#p99と#c00~#c99にマッチするかどうかを確認しています。

`/^[pc][0-9]{2}$/`

追記
[how to fix](http://ma.la/jquery_xss/)を参考に`location.hash.replace(/[^\w]/g, "")`を使う方法に書き換えました。
