### PR TITLE
Some more .travis.yml tweaks 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 bundler_args: --without development
 
 rvm:
-  - 1.8.6
   - 1.8.7
   - 1.9.2
-  - ruby-head
+  - 1.9.3
   - ree
+  - rbx
+  - rbx-2.0
 
 script: bundle exec rake spec


### PR DESCRIPTION
- Nokogiri won't work on 1.8.6 so testing against it probably makes no sense
- Today is #rbxday so add Rubinius master & 2.0.pre
- We now provide Ruby 1.9.3-preview1 as 1.9.3
