### PR TITLE
Make TravisCI run CI on jruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - ruby-head
+  - jruby
   - ree
 
 script: bundle exec rake spec


### PR DESCRIPTION
My forked tdiary-core branch[1] run CI fine[2].

[1] https://github.com/nahi/tdiary-core/tree/travis-jruby-sandbox
[2] http://travis-ci.org/#!/nahi/tdiary-core
