### PR TITLE
Add JRuby back to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 1.9.3
   - ruby-head
   - ree
+  - jruby
 
 script: bundle exec rake spec
 


### PR DESCRIPTION
The "Connection Refused" issue is now resolved, lets add JRuby back to the build matrix
