### PR TITLE
use String.encode when running on ruby-head

### DIFF
--- a/tdiary/lang/en.rb
+++ b/tdiary/lang/en.rb
@@ -1,21 +1,21 @@
 # -*- coding: utf-8; -*-
 #
-# tDiary language setup: English(en) $Revision: 1.5 $
+# tDiary language setup: English(en)
 #
-# Copyright (C) 2001-2005, TADA Tadashi <t@tdtds.jp>
+# Copyright (C) 2001-2011, TADA Tadashi <t@tdtds.jp>
 # You can redistribute it and/or modify it under GPL2.
 #
 
 #
 # 'html_lang' method returns String of HTML language attribute.
-# 
+#
 def html_lang
 	'en-US'
 end
 
 #
 # 'encoding' method returns String of HTTP or HTML charactor encoding.
-# 
+#
 def encoding
 	'UTF-8'
 end
@@ -24,16 +24,16 @@ def encoding_old
 	'UTF-8'
 end
 
-
 #
 # 'mobile_encoding' method returns charactor encoding in mobile mode.
+#
 def mobile_encoding
 	'UTF-8'
 end
 
 #
 # 'to_native' method converts string automatically to native encoding.
-# 
+#
 def to_native( str, charset = nil )
 	str.dup
 end
@@ -47,21 +47,21 @@ end
 
 #
 # 'to_mobile' method converts string automatically to mobile mode encoding.
-# 
+#
 def to_mobile( str )
 	str.dup
 end
 
 #
 # 'to_mail' method converts string automatically to E-mail encoding.
-# 
+#
 def to_mail( str )
 	str.dup
 end
 
 #
 # 'shorten' method cuts string length.
-# 
+#
 def shorten( str, length = 120 )
 	matched = str.gsub( /\n/, ' ' ).scan( /^.{0,#{length - 2}}/u )[0]
 	unless $'.empty?

--- a/tdiary/lang/ja.rb
+++ b/tdiary/lang/ja.rb
@@ -2,15 +2,11 @@
 #
 # tDiary language setup: Japanese(ja)
 #
-# Copyright (C) 2001-2007, TADA Tadashi <t@tdtds.jp>
+# Copyright (C) 2001-2011, TADA Tadashi <t@tdtds.jp>
 # You can redistribute it and/or modify it under GPL2.
 #
 
 require 'nkf'
-begin
-	require "iconv"
-rescue LoadError
-end
 
 def html_lang
 	'ja-JP'
@@ -30,7 +26,12 @@ end
 
 def to_native( str, charset = nil )
 	begin
-		Iconv.conv('utf-8', charset || 'utf-8', str)
+		if String.method_defined?(:encode)
+			str.encode('utf-8')
+		else
+			require "iconv"
+			Iconv.conv('utf-8', charset || 'utf-8', str)
+		end
 	rescue
 		from = case charset
 			when /^utf-8$/i
@@ -56,7 +57,12 @@ end
 
 def to_mail( str )
 	begin
-		Iconv.conv('iso-2022-jp', 'utf-8', str)
+		if String.method_defined?(:encode)
+			str.encode('iso-2022-jp')
+		else
+			require "iconv"
+			Iconv.conv('iso-2022-jp', 'utf-8', str)
+		end
 	rescue
 		NKF::nkf('-m0 -W -j', str)
 	end

--- a/tdiary/lang/zh.rb
+++ b/tdiary/lang/zh.rb
@@ -1,27 +1,28 @@
 # -*- coding: utf-8; -*-
 #
-# tDiary language setup: (zh) $Revision: 1.4 $
+# tDiary language setup: (zh)
 #
-# Copyright (C) 2001-2005, TADA Tadashi <t@tdtds.jp>
+# Copyright (C) 2001-2011, TADA Tadashi <t@tdtds.jp>
 # You can redistribute it and/or modify it under GPL2.
 #
 
 #
 # 'html_lang' method returns String of HTML language attribute.
-# 
+#
 def html_lang
 	'zh-TW'
 end
 
 #
 # 'encoding' method returns String of HTTP or HTML charactor encoding.
-# 
+#
 def encoding
 	'UTF-8'
 end
 
 #
 # 'mobile_encoding' method returns charactor encoding in mobile mode.
+#
 def mobile_encoding
 	'UTF-8'
 end
@@ -30,10 +31,9 @@ def encoding_old
 	'Big5'
 end
 
-
 #
 # 'to_native' method converts string automatically to native encoding.
-# 
+#
 def to_native( str, charset = nil )
 	str.dup
 end
@@ -42,27 +42,31 @@ end
 # 'migrate_to_utf8' method converts string to UTF-8
 #
 def migrate_to_utf8( str )
-	require 'iconv'
-	Iconv::iconv( encoding, encoding_old, str )
+	if String.method_defined?(:encode)
+		str.encode(encoding)
+	else
+		require 'iconv'
+		Iconv::iconv( encoding, encoding_old, str )
+	end
 end
 
 #
 # 'to_mobile' method converts string automatically to mobile mode encoding.
-# 
+#
 def to_mobile( str )
 	str.dup
 end
 
 #
 # 'to_mail' method converts string automatically to E-mail encoding.
-# 
+#
 def to_mail( str )
 	str.dup
 end
 
 #
 # 'shorten' method cuts string length.
-# 
+#
 def shorten( str, length = 120 )
 	matched = str.gsub( /\n/, ' ' ).scan( /^.{0,#{length - 2}}/ )[0]
 	unless $'.empty?


### PR DESCRIPTION
ruby-head では iconv を使おうとすると warning を出すので apache2 のログが warning だけで埋まってしまいます。ちゃんと String.encode があるときはそっちを使うようにしてみました。
