### PR TITLE
remove erb_fast

### DIFF
--- a/tdiary.rb
+++ b/tdiary.rb
@@ -17,11 +17,7 @@ require 'uri'
 require 'logger'
 require 'pstore'
 require 'json'
-begin
-	require 'erb_fast'
-rescue LoadError
-	require 'erb'
-end
+require 'erb'
 require 'tdiary/compatible'
 require 'tdiary/core_ext'
 


### PR DESCRIPTION
`erb_fast` は最終バージョンが 2003 年と古く、さらに trunk ではコンパイルできず、[コンパイルできるようにしたもの](https://github.com/hsbt/erbscan)でもエンコーディングの問題で動かないようです。

上記のような状態なので削除したいです。いかがでしょうか。
