### PR TITLE
Rack環境においてサブディレクトリへデプロイ可能にする

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,7 +3,9 @@ require 'tdiary/application'
 
 use Rack::Reloader
 
-map '/assets' do
+base_dir = ''
+
+map "#{base_dir}/assets" do
 	environment = Sprockets::Environment.new
 	['js', 'theme', '../tdiary-contrib/js', '../tdiary-theme'].each do |path|
 		environment.append_path path
@@ -11,15 +13,15 @@ map '/assets' do
 	run environment
 end
 
-map "/" do
+map "#{base_dir}/" do
 	run TDiary::Application.new(:index)
 end
 
-map "/index.rb" do
+map "#{base_dir}/index.rb" do
 	run TDiary::Application.new(:index)
 end
 
-map "/update.rb" do
+map "#{base_dir}/update.rb" do
 	use Rack::Auth::Basic do |user, pass|
 		if File.exist?('.htpasswd')
 			require 'webrick/httpauth/htpasswd'


### PR DESCRIPTION
Rack環境で動作させる場合でも`http://example.com/tdiary/` のようにサブディレクトリへもデプロイしたいです。
Railsの方法（環境変数 RAILS_RELATIVE_URL_ROOT を渡す）でも良いのですが、
まずはconfig.ruを書き換える方法でパッチを書きました。
