### PR TITLE
Rack環境においてpublicディレクトリの静的コンテンツを返したい

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -14,11 +14,10 @@ map "#{base_dir}/assets" do
 end
 
 map "#{base_dir}/" do
-	run TDiary::Application.new(:index)
-end
-
-map "#{base_dir}/index.rb" do
-	run TDiary::Application.new(:index)
+	run Rack::Cascade.new([
+		Rack::File.new("./public/"),
+		TDiary::Application.new(:index)
+	])
 end
 
 map "#{base_dir}/update.rb" do


### PR DESCRIPTION
Rack環境で動作させる場合に、index.rdfなどのpublicディレクトリに置いたファイルを返すようにしたい。
静的コンテンツがあればそれを、無ければ`TDiary::Application`を起動するようにした。
