### PR TITLE
Rack環境でhtml_anchorプラグインを使いたい

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,6 @@
 $:.unshift( File::dirname( __FILE__ ).untaint )
 require 'tdiary/application'
+require 'tdiary/rack/html_anchor'
 
 use Rack::Reloader
 
@@ -14,7 +15,7 @@ map "#{base_dir}/assets" do
 end
 
 map "#{base_dir}/" do
-	use TDiary::HtmlAnchor
+	use TDiary::Rack::HtmlAnchor
 	run Rack::Cascade.new([
 		Rack::File.new("./public/"),
 		TDiary::Application.new(:index)

--- a/tdiary/application.rb
+++ b/tdiary/application.rb
@@ -49,21 +49,6 @@ module TDiary
 			$stdin = stdin_spy
 		end
 	end
-
-	class HtmlAnchor
-		def initialize( app )
-			@app = app
-		end
-
-		def call( env )
-			req = Rack::Request.new( env )
-			if env['PATH_INFO'].match(/([0-9\-]+)\.html$/)
-				env["QUERY_STRING"] += "&" unless env["QUERY_STRING"].empty?
-				env["QUERY_STRING"] += "date=#{$1}"
-			end
-			@app.call( env )
-		end
-	end
 end
 
 # Local Variables:

--- a/tdiary/rack/html_anchor.rb
+++ b/tdiary/rack/html_anchor.rb
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+module TDiary
+	module Rack
+		class HtmlAnchor
+			def initialize( app )
+				@app = app
+			end
+
+			def call( env )
+				if env['PATH_INFO'].match(/([0-9\-]+)\.html$/)
+					env["QUERY_STRING"] += "&" unless env["QUERY_STRING"].empty?
+					env["QUERY_STRING"] += "date=#{$1}"
+				end
+				@app.call( env )
+			end
+		end
+	end
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:


### PR DESCRIPTION
Rack環境でhtml_anchorプラグインが動作するように、
YYYYMMDD.html形式のリクエストをdate=YYYYMMDDに変換する
Rackミドルウェア (TDiary::HtmlAnchor) を作成しました。

＃ 他のpull_requestとコンフリクトするかもしれません。
