### PR TITLE
add task auth:password:create

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -124,6 +124,34 @@ task :compile do
 	end
 end
 
+namespace :auth do
+	desc "create password"
+	namespace :password do
+		task :create do
+			require 'webrick/httpauth/htpasswd'
+			print 'Username: '
+			ARGV.replace([])
+			username = gets().chop
+			print 'New password: '
+			system "stty -echo"
+			password = $stdin.gets.chop
+			puts
+			print 'Re-type new password: '
+			password2 = $stdin.gets.chop
+			puts
+			system "stty echo"
+			if password != password2
+				puts 'password verification error'
+			else
+				htpasswd = WEBrick::HTTPAuth::Htpasswd.new('.htpasswd')
+				htpasswd.set_passwd(nil, username, password)
+				htpasswd.flush
+				puts "Adding password for user #{username}"
+			end
+		end
+	end
+end
+
 if ENV['DATABASE_URL']
 	desc "create database"
 	namespace :db do


### PR DESCRIPTION
`.htpasswd` ファイルを生成するRakeタスクを追加しました。
`webrick/httpauth/htpasswd`を使用しているので `htpasswd` コマンドがない環境でも動作します。

```
$ rake auth:password:create
Username: machu
New password: 
Re-type new password: 
Adding password for user machu
```

see #156
