### PR TITLE
HEADリクエスト時に404の場合はレスポンスボディを空にしたい

### DIFF
--- a/spec/core/rack/valid_request_path_spec.rb
+++ b/spec/core/rack/valid_request_path_spec.rb
@@ -44,6 +44,9 @@ describe TDiary::Rack::ValidRequestPath do
 			last_response.status.should be 404
 			get '/invalid'
 			last_response.status.should be 404
+			head '/invalid'
+			last_response.status.should be 404
+			last_response.body.length.should be 0
 		end
 
 		it 'should return 404 for access to the invalid directory' do

--- a/tdiary/rack/valid_request_path.rb
+++ b/tdiary/rack/valid_request_path.rb
@@ -16,7 +16,13 @@ module TDiary
 				valid_paths.each do |path|
 					return @app.call(env) if env['PATH_INFO'].match(path)
 				end
-				[404, {'Content-Type' => 'text-plain'}, ["Not Found: #{env['PATH_INFO']}"]]
+
+				body = "Not Found: #{env['PATH_INFO']}"
+				if env["REQUEST_METHOD"] == "HEAD"
+					[404, {'Content-Type' => 'text/plain', 'Content-Length' => body.length.to_s}, []]
+				else
+					[404, {'Content-Type' => 'text/plain'}, [body]]
+				end
 			end
 		end
 	end


### PR DESCRIPTION
HEADリクエスト時に 404 となったときの以下のエラーとなるものへの対応です．

ERROR -- : app error: Response body was given for HEAD request, but should be empty (Rack::Lint::LintError)
