### PR TITLE
Another fix to makerss infinite loop on invalid URL from

### DIFF
--- a/misc/plugin/makerss.rb
+++ b/misc/plugin/makerss.rb
@@ -727,6 +727,7 @@ def absolutify(html, baseurl)
 					end
 					tag = prefix + location + postfix
 				rescue URI::InvalidURIError
+				rescue ArgumentError
 				end
 			end
 		end


### PR DESCRIPTION
#213 への別解です。rescue URI::InvalidURIError と似た状況と思われるので、入力を加工せず処理するようにしてみました。

ref. https://github.com/zunda/ruby-absolutify/commit/a55b7c1703542c86afe807b0c33248003a72dcb8
