### PR TITLE
Modified to suppress output when there is no weather data

### DIFF
--- a/misc/plugin/en/weather.rb
+++ b/misc/plugin/en/weather.rb
@@ -62,6 +62,7 @@ class Weather
 
 	# edit this method to define how you show the weather
 	def html_string
+		has_data = false
 		r = '<span class="weather">'
 
 		# weather
@@ -70,16 +71,18 @@ class Weather
 		if @data['weather'] then
 			r << %Q|<span class="weather">#{h( WeatherTranslator::S.new( @data['weather']).translate( Words_en ).compact.capitalize )}</span>|
 			has_condition = true
+			has_data = true
 		elsif @data['condition'] then
 			r << %Q|<span class="condition">#{h( WeatherTranslator::S.new( @data['condition']).translate( Words_en ).compact.capitalize )}</span>|
 			has_condition = true
+			has_data = true
 		end
 
 		# temperature
 		if @data['temperature(C)'] and t = @data['temperature(C)'].scan(/-?[\d.]+/)[-1] then
 			r << ', ' if has_condition
 			r << %Q| <span class="temperature">#{sprintf( '%.0f', 9.0/5.0 * t.to_f + 32.0 )} deg-F</span>|
-			#r << %Q| <span class="temperature">#{sprintf( '%.0f', t )} deg-C</span>|
+			has_data = true
 		end
 		r << '</a>'
 
@@ -99,6 +102,7 @@ class Weather
 		end
 
 		r << "</span>"
+		return has_data ? r : ''
 	end
 
 	# edit this method to define how you show the weather for a mobile agent
@@ -116,6 +120,7 @@ class Weather
 			r << "</A>"
 		end
 
+		return r
 	end
 end
 

--- a/misc/plugin/ja/weather.rb
+++ b/misc/plugin/ja/weather.rb
@@ -284,6 +284,7 @@ class Weather
 
 	# edit this method to define how you show the weather
 	def html_string
+		has_data = false
 		r = '<span class="weather">'
 
 		# time stamp
@@ -305,16 +306,20 @@ class Weather
 		r << %Q|<a href="#{h(@url)}">|
 		if @data['weather'] then
 			r << %Q|<span class="weather">#{h( WeatherTranslator::S.new( @data['weather']).translate( Words_ja ).compact )}</span>|
+			has_data = true
 		elsif @data['condition'] then
 			r << %Q|<span class="condition">#{h( WeatherTranslator::S.new( @data['condition']).translate( Words_ja ).compact )}</span>|
+			has_data = true
 		end
 
 		# temperature
 		if @data['temperature(C)'] and t = @data['temperature(C)'].scan(/-?[\d.]+/)[-1] then
 			r << %Q| <span class="temperature">#{sprintf( '%.0f', t )}℃</span>|
+			has_data = true
 		end
 
 		r << "</a></span>"
+		return has_data ? r : ''
 	end
 
 	# edit this method to define how you show the weather for a mobile agent
@@ -332,6 +337,7 @@ class Weather
 			r << "</A>"
 		end
 
+		return r
 	end
 end
 


### PR DESCRIPTION
#155 NOAA changed format of current surface weather pages への対応のほんの一部です。

データの形式が変更になってからは空のデータが記録れるようになってしまいました。その場合に日記にタイムスタンプのみが表示されてしまうのを防ぐ変更です。
