### PR TITLE
run ValidRequestPath after Rack::File to return public contents

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -47,10 +47,9 @@ end
 
 map "#{base_dir}/" do
 	use TDiary::Rack::HtmlAnchor
-	use TDiary::Rack::ValidRequestPath
 	run Rack::Cascade.new([
 		Rack::File.new("./public/"),
-		TDiary::Application.new(:index)
+		TDiary::Rack::ValidRequestPath.new(TDiary::Application.new(:index))
 	])
 end
 


### PR DESCRIPTION
Rack::Fileの実行後にValidRequestPathを実行するよう順序を変更しました。Rack::Cascade内で実行するため、RackミドルウェアではなくRackアプリケーションとして呼び出します。

fixed #237 
