### PR TITLE
record up to 10,000 of the volatile referer

### DIFF
--- a/plugin/05referer.rb
+++ b/plugin/05referer.rb
@@ -219,7 +219,7 @@ end
 
 def referer_save_volatile( diary, referer )
 	# to prevend the increase in file size
-	return if diary.count_referers > 1000
+	return if diary.count_referers > 10000
 	diary.add_referer( referer ) if referer
 	referer_save( referer_volatile_file_name, diary ) do |fh|
 		diary.each_date do |date|


### PR DESCRIPTION
#241 の対応です。

ひとまず「以前の日記へのリンク元」の保存件数を最大1万件としました。
