### PR TITLE
migrate spamlookup instead of spam-champuru

### DIFF
--- a/plugin/10spamfilter.rb
+++ b/plugin/10spamfilter.rb
@@ -118,7 +118,8 @@ add_conf_proc( 'spamfilter', @spamfilter_label_conf, 'security' ) do
 	end
 
 	# initialize IP based DNSBL list
-	@conf['spamlookup.ip.list'] ||= "dnsbl.spam-champuru.livedoor.com"
+	@conf['spamlookup.ip.list'] ||= "bsb.spamlookup.net"
+	auto_migration_spam_champuru
 
 	# initialize DNSBL list
 	@conf['spamlookup.domain.list'] ||= "bsb.spamlookup.net\nsc.surbl.org\nrbl.bulkfeeds.jp"
@@ -155,6 +156,7 @@ add_conf_proc( 'dnsblfilter', @dnsblfilter_label_conf, 'security' ) do
 
 	# initialize IP based DNSBL list
 	@conf['spamlookup.ip.list'] ||= "dnsbl.spam-champuru.livedoor.com"
+	auto_migration_spam_champuru
 
 	# initialize DNSBL list
 	@conf['spamlookup.domain.list'] ||= "bsb.spamlookup.net\nsc.surbl.org\nrbl.bulkfeeds.jp"
@@ -165,6 +167,13 @@ add_conf_proc( 'dnsblfilter', @dnsblfilter_label_conf, 'security' ) do
 	dnsblfilter_conf_html
 end
 
+def auto_migration_spam_champuru
+	# auto migration of spam-champuru shutdown.
+	if @conf['spamlookup.ip.list'].scan(/dnsbl\.spam-champuru\.livedoor\.com/).size > 0
+		@conf['spamlookup.ip.list'].gsub!(/dnsbl\.spam-champuru\.livedoor\.com/, "bsb.spamlookup.net")
+	end
+end
+
 # Local Variables:
 # mode: ruby
 # indent-tabs-mode: t
@@ -172,4 +181,3 @@ end
 # ruby-indent-level: 3
 # End:
 # vim: ts=3
-

--- a/spec/acceptance/save_conf_dnsbl_spec.rb
+++ b/spec/acceptance/save_conf_dnsbl_spec.rb
@@ -3,6 +3,18 @@ require 'acceptance_helper'
 require 'resolv'
 
 feature 'spamフィルタ設定の利用', :exclude_selenium do
+	scenario 'IPベースのブラックリストの spam-champuru が spamlookup に置き換わる' do
+		visit '/update.rb?conf=dnsblfilter'
+		fill_in 'spamlookup.ip.list', :with => "dnsbl.spam-champuru.livedoor.com"
+		fill_in 'spamlookup.domain.list', :with => ""
+		fill_in 'spamlookup.safe_domain.list', :with => ""
+		page.all('div.saveconf').first.click_button 'OK'
+
+		visit '/update.rb?conf=dnsblfilter'
+		page.should have_no_content "dnsbl.spam-champuru.livedoor.com"
+		page.should have_content "bsb.spamlookup.net"
+	end
+
 	scenario 'IPベースのブラックリストが動作する' do
 		IPSocket.stub(:getaddress) { '127.0.0.1' }
 		Resolv.stub(:getaddress) { '127.0.0.1' }
@@ -10,7 +22,7 @@ feature 'spamフィルタ設定の利用', :exclude_selenium do
 		append_default_diary
 
 		visit '/update.rb?conf=dnsblfilter'
-		fill_in 'spamlookup.ip.list', :with => "dnsbl.spam-champuru.livedoor.com"
+		fill_in 'spamlookup.ip.list', :with => "bsb.spamlookup.net"
 		fill_in 'spamlookup.domain.list', :with => ""
 		fill_in 'spamlookup.safe_domain.list', :with => ""
 		page.all('div.saveconf').first.click_button 'OK'
@@ -35,7 +47,7 @@ BODY
 		append_default_diary
 
 		visit '/update.rb?conf=dnsblfilter'
-		fill_in 'spamlookup.ip.list', :with => "dnsbl.spam-champuru.livedoor.com"
+		fill_in 'spamlookup.ip.list', :with => "bsb.spamlookup.net"
 		fill_in 'spamlookup.domain.list', :with => ""
 		fill_in 'spamlookup.safe_domain.list', :with => ""
 		page.all('div.saveconf').first.click_button 'OK'
@@ -111,7 +123,7 @@ BODY
 		append_default_diary
 
 		visit '/update.rb?conf=dnsblfilter'
-		fill_in 'spamlookup.ip.list', :with => "dnsbl.spam-champuru.livedoor.com"
+		fill_in 'spamlookup.ip.list', :with => "bsb.spamlookup.net"
 		fill_in 'spamlookup.domain.list', :with => "bsb.spamlookup.net"
 		fill_in 'spamlookup.safe_domain.list', :with => "www.example.com"
 		page.all('div.saveconf').first.click_button 'OK'


### PR DESCRIPTION
#272 の対応です。使えないので置きかえましたみたいな説明文も必要かなあ。
