### PR TITLE
tdiary/io/cache/memcached.rbがちゃんと動いてないのを修正

### DIFF
--- a/tdiary/io/cache/memcached.rb
+++ b/tdiary/io/cache/memcached.rb
@@ -48,7 +48,7 @@ module TDiary
 		end
 
 		def store_parser_cache(date, obj, key = nil)
-			store_data(date.strftime("%Y%m.parser"), obj)
+			store_data(obj, date.strftime("%Y%m.parser"))
 		end
 
 		def clear_parser_cache(*args)


### PR DESCRIPTION
- 7f0c9fd5b0e47259ce4175aee6d1fa7a1c3496ab でoptions.merge!の使い方がおかしいのを直しました
- d38d61ad611e70fe1118338726c34f64e9a600c5 でstore_parser_cache()の中でmemcache.set(key, value)になってたのを(最終的に)memcache.set(value, key)で、keyにvalueを突っ込むようになっていたのを直しました。月の日記のデータがでかいとkeyが長すぎでmemcacheに起こられます。(それにkeyをstoreしても…)
