### PR TITLE
Rack 環境にて Encoding::default_external 未初期化によるエラーの修正

### DIFF
--- a/index.rb
+++ b/index.rb
@@ -7,11 +7,6 @@
 # You can redistribute it and/or modify it under GPL2.
 #
 BEGIN { $stdout.binmode }
-begin
-	Encoding::default_external = 'UTF-8'
-rescue NameError
-	$KCODE = 'n'
-end
 
 begin
 	if FileTest::symlink?( __FILE__ ) then

--- a/tdiary.rb
+++ b/tdiary.rb
@@ -11,6 +11,11 @@ TDIARY_VERSION = '3.2.1.20130329'
 
 $:.unshift File.join(File::dirname(__FILE__), '/misc/lib').untaint
 Dir["#{File::dirname(__FILE__) + '/vendor/*/lib'}"].each {|dir| $:.unshift dir.untaint }
+begin
+	Encoding::default_external = 'UTF-8'
+rescue NameError
+	$KCODE = 'n'
+end
 
 require 'cgi'
 require 'uri'

--- a/update.rb
+++ b/update.rb
@@ -7,11 +7,6 @@
 # You can redistribute it and/or modify it under GPL2.
 #
 BEGIN { $stdout.binmode }
-begin
-	Encoding::default_external = 'UTF-8'
-rescue NameError
-	$KCODE = 'n'
-end
 
 begin
 	if FileTest::symlink?( __FILE__ ) then


### PR DESCRIPTION
Rack 環境では Encoding::default_external が初期化されずに tdiary.conf の読み込みが行わるようで、最低限の環境変数下で実行した際にエンコーディングエラーとなりました。tdiary.conf にマジックコメントを追加して回避しても別の箇所で類似のエラーとなるため、共通処理として初期化させたところ、正しく動作するようになりました。

Ruby 1.9 以降の現象ですが、個々のスクリプトにはマジックコメントが書かれていので tdiary.rb に集約して問題ないかと思い index.rb, update.rb での処理は削除しています。

Ruby: 2.0p0
OS: FreeBSD 9.1R
Backtrace:

```
Exception handling servers: (tdiary.conf):143: invalid multibyte char (US-ASCII)
(tdiary.conf):141: syntax error, unexpected end-of-input, expecting tSTRING_CONTENT or tSTRING_DBEG or tSTRING_DVAR or tSTRING_END (SyntaxError)
/usr/home/tdiary/tdiary-core/tdiary/config.rb:120:in `eval'
/usr/home/tdiary/tdiary-core/tdiary/config.rb:120:in `configure_attrs'
/usr/home/tdiary/tdiary-core/tdiary/config.rb:12:in `initialize'
/usr/home/tdiary/tdiary-core/tdiary/dispatcher/index_main.rb:14:in `new'
/usr/home/tdiary/tdiary-core/tdiary/dispatcher/index_main.rb:14:in `initialize'
/usr/home/tdiary/tdiary-core/tdiary/dispatcher/index_main.rb:6:in `new'
/usr/home/tdiary/tdiary-core/tdiary/dispatcher/index_main.rb:6:in `run'
/usr/home/tdiary/tdiary-core/tdiary/dispatcher.rb:21:in `dispatch_cgi'
/usr/home/tdiary/tdiary-core/tdiary/application.rb:37:in `dispatch_request'
/usr/home/tdiary/tdiary-core/tdiary/application.rb:21:in `call'
/usr/home/tdiary/tdiary-core/tdiary/rack/valid_request_path.rb:17:in `block in call'
/usr/home/tdiary/tdiary-core/tdiary/rack/valid_request_path.rb:16:in `each'
/usr/home/tdiary/tdiary-core/tdiary/rack/valid_request_path.rb:16:in `call'
/home/tdiary/vendor/ruby/2.0/gems/rack-1.5.2/lib/rack/cascade.rb:33:in `block in call'
/home/tdiary/vendor/ruby/2.0/gems/rack-1.5.2/lib/rack/cascade.rb:24:in `each'
/home/tdiary/vendor/ruby/2.0/gems/rack-1.5.2/lib/rack/cascade.rb:24:in `call'
/usr/home/tdiary/tdiary-core/tdiary/rack/html_anchor.rb:20:in `call'
/home/tdiary/vendor/ruby/2.0/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
/home/tdiary/vendor/ruby/2.0/gems/rack-1.5.2/lib/rack/urlmap.rb:65:in `block in call'
/home/tdiary/vendor/ruby/2.0/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `each'
/home/tdiary/vendor/ruby/2.0/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `call'
/home/tdiary/vendor/ruby/2.0/gems/omniauth-1.1.4/lib/omniauth/builder.rb:49:in `call'
/home/tdiary/vendor/ruby/2.0/gems/rack-1.5.2/lib/rack/session/abstract/id.rb:225:in `context'
/home/tdiary/vendor/ruby/2.0/gems/rack-1.5.2/lib/rack/session/abstract/id.rb:220:in `call'
/home/tdiary/vendor/ruby/2.0/bundler/gems/puma-cc91b6cd5117/lib/puma/configuration.rb:66:in `call'
/home/tdiary/vendor/ruby/2.0/bundler/gems/puma-cc91b6cd5117/lib/puma/server.rb:364:in `handle_request'
/home/tdiary/vendor/ruby/2.0/bundler/gems/puma-cc91b6cd5117/lib/puma/server.rb:243:in `process_client'
/home/tdiary/vendor/ruby/2.0/bundler/gems/puma-cc91b6cd5117/lib/puma/server.rb:142:in `block in run'
/home/tdiary/vendor/ruby/2.0/bundler/gems/puma-cc91b6cd5117/lib/puma/thread_pool.rb:92:in `call'
/home/tdiary/vendor/ruby/2.0/bundler/gems/puma-cc91b6cd5117/lib/puma/thread_pool.rb:92:in `block in spawn_thread'
```
