### PR TITLE
CLI "tdiary new" without bundler way

### DIFF
--- a/tdiary/cli.rb
+++ b/tdiary/cli.rb
@@ -12,15 +12,21 @@ module TDiary
 		end
 
 		desc "new DIR_NAME", "Create a new tDiary directory"
+		method_option "skip-bundle", :type => :boolean, :banner =>
+			"don't run bundle and .htpasswd generation"
 		def new(name)
 			target = File.join(Dir.pwd, name)
 			deploy(target)
 
-			Bundler.with_clean_env do
-				inside(target) do
-					run('bundle install --without test development')
-					run('bundle exec tdiary htpasswd')
+			unless options[:'skip-bundle']
+				Bundler.with_clean_env do
+					inside(target) do
+						run('bundle install --without test development')
+						run('bundle exec tdiary htpasswd')
+					end
 				end
+			else
+				say "run `bundle install && bundle exec tdiary htpasswd` manually", :red
 			end
 			say 'install finished', :green
 			say "run `tdiary server` in #{name} directory to start server", :green


### PR DESCRIPTION
待望の ruby-gems 対応、早速導入させてもらいました。

tdiary new のセットアップ時に bundler によってインストールされる gem たちを、標準の gem place から隔離したい事情があり、bundler を走らせないパッチを書きました(他の非 bundler なアプリケーションに影響がでる、new コマンドを打つユーザが suders でない等)。後に手動で bundle install --path foo/bar する用途です。

rails new のそれと同じインターフェイス --skip-bundle としましたが、直接 bundle install に任意のオプションをバイパスするような方法でもよかったかもしれません。
