### PR TITLE
CDNを指定しているjQueryのURLを protocol-relative URLに変更

### DIFF
--- a/plugin/00default.rb
+++ b/plugin/00default.rb
@@ -353,7 +353,7 @@ def description_tag
 end
 
 def jquery_tag
-	%Q[<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8/jquery.min.js" type="text/javascript"></script>]
+	%Q[<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8/jquery.min.js" type="text/javascript"></script>]
 end
 
 enable_js( '00default.js' )


### PR DESCRIPTION
SSL環境で運用する際に，jQueryのURLでhttp:が指定されていると読み込めないため protocol-relative URL に変更しました．
