### PR TITLE
Support my plugin in fn plugin for RD style

### DIFF
--- a/misc/style/rd/rd_style.rb
+++ b/misc/style/rd/rd_style.rb
@@ -99,8 +99,8 @@ module RD
 		end
 
 		def apply_to_Footnote(element, content)
-			heredoc_id = "%0.32b" % rand( 0x100000000 )
-			%Q|<%=fn <<'#{heredoc_id}' \n #{content.join}\n#{heredoc_id}\n%>|
+			escaped_content = content.join.gsub( /%>/, "%%>" )
+			%Q|<%=fn apply_plugin( #{escaped_content.dump} ) %>|
 		end
 
 		def apply_to_RefToElement(element, content)

--- a/spec/core/style/rd_style_spec.rb
+++ b/spec/core/style/rd_style_spec.rb
@@ -172,6 +172,28 @@ aaa</p>
 		end
 	end
 
+	describe 'fn' do
+		context 'my' do
+			before do
+				source = <<-'EOF'
+((-((<20130714>))-))
+				EOF
+				@diary.append(source)
+			end
+
+			before do
+				@html = <<-'EOF'
+<div class="section">
+<%=section_enter_proc( Time::at( 1041346800 ))%>
+<p><%=fn apply_plugin( "<%=my \"20130714\",\"20130714\"%%>" ) %></p>
+<%=section_leave_proc( Time::at( 1041346800 ))%>
+</div>
+				EOF
+			end
+			it { @diary.to_html.should eq @html }
+		end
+	end
+
 	describe 'test_rd_on_error' do
 		context 'link' do
 			before do


### PR DESCRIPTION
RD style expands

```
((-((<20130714>))-))
```

to

```
<%= fn <<-'0000random_id1111'
<%=my "20130714","20130714"%>
0000random_id1111
%>
```

"%>" in "<%= ... %>" confuses ERB:

```
% echo '<%= eval("<= 1 + 1 %>") %>' | erb -x
#coding:ASCII-8BIT
_erbout = ''; _erbout.concat(( eval("<= 1 + 1 ).to_s); _erbout.concat "\") %>\n"
; _erbout.force_encoding(__ENCODING__)
```

'eval("<%= 1 + 1 )...' is broken.

So "%>" should be escaped as "%%>".
