### PR TITLE
Refine snapshot task

### DIFF
--- a/tdiary/tasks/release.rake
+++ b/tdiary/tasks/release.rake
@@ -11,7 +11,7 @@ TARBALLS = []
 def fetch_files( repo )
 	Dir.chdir("tmp") do
 		rm_rf repo rescue true
-		sh "git clone --depth 1 https://github.com/tdiary/#{repo}.git #{repo}"
+		sh "git clone --depth 10 https://github.com/tdiary/#{repo}.git #{repo}"
 	end
 end
 


### PR DESCRIPTION
fixes #327 

snapshot が作れなくなっていたので、色々直しました。今後は snapshot パッケージには snapshot という suffix を付けるようにします。
