### PR TITLE
preタグ内で大なり小なり記号などがエスケープされない問題を修正

### DIFF
--- a/misc/style/gfm/gfm_style.rb
+++ b/misc/style/gfm/gfm_style.rb
@@ -26,8 +26,9 @@ class HTMLwithPygments < Redcarpet::Render::HTML
 		require 'pygments'
 		Pygments.highlight(code, :lexer => language)
 	rescue Exception
+ 		escaped = CGI.escapeHTML(code)
 		<<-HTML
-<div class="highlight"><pre>#{code}</pre></div>
+<div class="highlight"><pre>#{escaped}</pre></div>
 		HTML
 	end
 end


### PR DESCRIPTION
githubではちゃんと prompt > と表示されますが、tDiaryのGFMスタイルでは > がエスケープされず、ブラウザ上で表示されないのを対応してみました。

例)
    prompt > linux command hoo

修正方法が雑かもしれませんがアイデアがありませんでした。すみません。
