### PR TITLE
document_root should be handled condition of request.

### DIFF
--- a/misc/plugin/makerss.rb
+++ b/misc/plugin/makerss.rb
@@ -105,7 +105,7 @@ class MakeRssFull
 	def file
 		f = @conf['makerss.file'] || 'index.rdf'
 		f = 'index.rdf' if f.empty?
-		f =~ %r|^/| ? f : "#{TDiary.document_root}/#{f}"
+		f =~ %r|^/| ? f : "#{document_root}/#{f}"
 	end
 
 	def writable?
@@ -137,6 +137,14 @@ class MakeRssFull
 		u = "#{base_url}#{File.basename(file)}" if u.empty?
 		u
 	end
+
+	def document_root
+		if @cgi.is_a?(RackCGI)
+			File.join(TDiary.server_root, 'public')
+		else
+			TDiary.server_root
+		end
+	end
 end
 
 @makerss_rsses << MakeRssFull::new(@conf, @cgi)
@@ -154,7 +162,7 @@ class MakeRssNoComments < MakeRssFull
 	def file
 		f = @conf['makerss.no_comments.file'] || 'no_comments.rdf'
 		f = 'no_comments.rdf' if f.empty?
-		f =~ %r|^/| ? f : "#{TDiary.document_root}/#{f}"
+		f =~ %r|^/| ? f : "#{document_root}/#{f}"
 	end
 
 	def write( encoder )


### PR DESCRIPTION
Fixes #342 

@machu

make_rss.rb は `TDiary.document_root` を使っていますが、常に Rack を読み込むようにしたことで Document root が CGI で起動した時に不整合になってしまいました。僕の意見としては、Rack が読み込まれているかどうかではなくて、リクエストが Rack のアプリケーションサーバー経由なのか、CGI経由なのかで Document root は判定されるべきと思うので make_rss.rb で判定するようにしました。

今後は `@cgi` ではなくて `@request` を使うようにした上で、ビューやプラグインでは `@request` の状態で制御を切り替えるようにすると良いのかなあと思います。`@request.cgi?` とかの導入がよさそうです。
