### PR TITLE
GFMスタイルでAタグを本文に直接書き込んだ場合、ただしく表示されないバグを修正

### DIFF
--- a/misc/style/gfm/gfm_style.rb
+++ b/misc/style/gfm/gfm_style.rb
@@ -96,7 +96,9 @@ module TDiary
 
 			# ignore duplicate autolink
 			if r =~ /<a href="<a href="/
-				r.gsub!(/<a href="<a href=".*?" rel="nofollow">(.*?)<\/a>">(.*?)<\/a>/){ "<a href=\"#{$1}\" rel=\"nofollow\">#{$2}</a>" }
+				r.gsub!(/<a href="<a href=".*?" rel="nofollow">(.*?)<\/a>"(.*?)>(.*?)<\/a>/) do
+          "<a href=\"#{$1}\" rel=\"nofollow\"#{$2}>#{$3}</a>"
+        end
 			end
       # ignore auto imagelink
 			if r =~ /<img src="<a href="/

--- a/spec/core/style/gfm_style_spec.rb
+++ b/spec/core/style/gfm_style_spec.rb
@@ -156,6 +156,28 @@ http://www.google.com
 
   end
 
+  describe 'auto imagelink' do
+		before do
+			source = <<-EOF
+# subTitle
+
+<a href="http://www.exaple.com" target="_blank">Anchor</a>
+         EOF
+			@diary.append(source)
+			@html = <<-EOF
+<div class="section">
+<%=section_enter_proc( Time.at( 1041346800 ) )%>
+<h3><%= subtitle_proc( Time.at( 1041346800 ), "subTitle" ) %></h3>
+<p><a href="http://www.exaple.com" rel="nofollow" target="_blank">Anchor</a></p>
+<%=section_leave_proc( Time.at( 1041346800 ) )%>
+</div>
+         EOF
+		end
+
+		it { @diary.to_html.should eq @html }
+
+  end
+
 	describe 'url syntax with code blocks' do
 		before do
 			source = <<-'EOF'


### PR DESCRIPTION
バージョン3.2.2.20130720において、GFMスタイルを利用した場合、記事の本文に

``` html
<a href="http://www.example.com">example</a>
```

と書くと、

``` html
<a href="<a href="http://example.com" rel="nofollow">http://example.com</a>>example</a>
```

のように表示されてしまうバグがあったので、修正しました。
