### PR TITLE
`Bundler.require` loads only gems in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,12 @@ end
 # use edge tDiary contrib
 # gem 'tdiary-contrib', :git => 'git@github.com:tdiary/tdiary-contrib.git'
 
+gem 'rack'
+gem 'sprockets'
+gem 'hikidoc'
+gem 'rdtool'
+gem 'fastimage'
+
 group :coffee do
   gem 'coffee-script'
   gem 'therubyracer'
@@ -49,6 +55,7 @@ end
 group :development do
   gem 'pit', :require => false
   gem 'racksh', :require => false
+  gem 'rake'
 
   group :test do
     gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,12 +3,6 @@ PATH
   specs:
     tdiary (3.2.2.20130722)
       bundler (~> 1.3)
-      fastimage
-      hikidoc (>= 0.0.6)
-      rack (>= 1.0.0)
-      rake (>= 10.0.0)
-      rdtool (>= 0.6.0)
-      sprockets (>= 2.10)
       thor (~> 0.18)
 
 GEM
@@ -140,12 +134,17 @@ DEPENDENCIES
   coffee-script
   coveralls
   dalli
+  fastimage
+  hikidoc
   jasmine
   launchy
   pit
   pry
   pygments.rb
+  rack
   racksh
+  rake
+  rdtool
   redcarpet
   redis
   redis-namespace
@@ -153,6 +152,7 @@ DEPENDENCIES
   selenium-webdriver
   sequel
   simplecov
+  sprockets
   sqlite3
   tapp
   tdiary!

--- a/tdiary.gemspec
+++ b/tdiary.gemspec
@@ -20,13 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.2'
 
-  spec.add_dependency 'rack', '>= 1.0.0'
-  spec.add_dependency 'sprockets', '>= 2.10'
-  spec.add_dependency 'rake', '>= 10.0.0'
-  spec.add_dependency 'hikidoc', '>= 0.0.6'
-  spec.add_dependency 'rdtool', '>= 0.6.0'
-  spec.add_dependency 'fastimage'
-
   spec.add_dependency 'thor', '~> 0.18'
   spec.add_dependency "bundler", "~> 1.3"
 end


### PR DESCRIPTION
#349 の修正です。

`Bundler.require` でライブラリを自動ロードするためには、 Gemfile に記述が必要でした。
そのため、 tdiary.gemspec で指定している gem を Gemfile に移動しました。
