### PR TITLE
fix argument for StringIO

### DIFF
--- a/misc/plugin/image.rb
+++ b/misc/plugin/image.rb
@@ -180,7 +180,7 @@ if /^formplugin$/ =~ @mode then
 		images = image_list( date )
 	   if @cgi.params['plugin_image_addimage'][0]
 			@cgi.params['plugin_image_file'].each do |file|
-				extension, = image_info( file.path )
+				extension, = image_info( file )
 				file.rewind
 
 				if extension =~ /\A(#{image_ext})\z/i


### PR DESCRIPTION
#347 の修正です。

image_info(内部のFastImage)の引数としてTempfileのパスを渡していました。
cgi.rbではデータサイズによって Tempfile と StringIO とを使い分けるため、StringIOに対してpathメソッドを読んでしまった場合、アップロードに失敗してしまっていました。
