### PR TITLE
Gemfile.local を導入します

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ vendor/bundle/
 spec/reports
 doc/*.html
 .rspec
+/Gemfile.local

--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,10 @@ group :development do
     gem 'coveralls', :require => false
   end
 end
+
+# https://github.com/redmine/redmine/blob/master/Gemfile#L89
+local_gemfile = File.join(File.dirname(__FILE__), "Gemfile.local")
+if File.exists?(local_gemfile)
+  puts "Loading Gemfile.local ..." if $DEBUG # `ruby -d` or `bundle -v`
+  instance_eval File.read(local_gemfile)
+end


### PR DESCRIPTION
redmine のようなアプリケーションで bundler を使う場合、プラグインが使っている gem は redmine から見えなくなってしまうので、Gemfile.local というファイルに書いて使う。という hack が使われているようです。

というわけで tDiary でもこの方法は有用だと思うので導入します。今後、plugin 独自に使っている gem がある場合はこのファイルに書くと、git 管理されている Gemfile の外で使えるようになります。
