### PR TITLE
fix error running under Rack

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,5 @@
 $:.unshift( File::dirname( __FILE__ ).untaint )
+require 'tdiary'
 require 'tdiary/environment'
 require 'tdiary/application'
 


### PR DESCRIPTION
Rack配下で動かすと tdiary/application.rb の中で使っている tDiary.root が未定義でエラーになるので、それより前に tdiary.rb を require しておく必要があるのではないか。

とりあえず config.ru に入れてしまったが、他により良い場所があるかも知れない。
