### PR TITLE
スタイルの自動有効化

### DIFF
--- a/spec/core/io/default_spec.rb
+++ b/spec/core/io/default_spec.rb
@@ -81,6 +81,34 @@ describe TDiary::IO::Default do
 
   end
 
+  describe "#style" do
+    context "given Foo style" do
+      let(:io) { TDiary::IO::Default.new(DummyTDiary.new) }
+
+      before do
+        TDiary::Style.const_set(:FooSection, Class.new)
+        TDiary::Style.const_set(:FooDiary, Class.new)
+      end
+
+      it "activates a style automatically" do
+        style = io.style("Foo")
+        expect(style).to eq TDiary::Style::FooDiary
+        expect(style).to be < TDiary::Style::BaseDiary
+        expect(style).to be < TDiary::Style::CategorizableDiary
+        expect(TDiary::Style::FooSection).to be < TDiary::Style::BaseSection
+      end
+
+      it "raises a BadStyleError when style is unknown" do
+        expect { io.style("Bar") }.to raise_error(TDiary::BadStyleError)
+      end
+
+      after do
+        TDiary::Style.send(:remove_const, :FooSection)
+        TDiary::Style.send(:remove_const, :FooDiary)
+      end
+    end
+  end
+
   before(:all) do
     ["/tmp/tdiary.conf", "/tmp/#{Time.now.year}"].each do |file|
       FileUtils.rm_rf TDiary.root + file


### PR DESCRIPTION
#401 の件ですが、定数を探索して自動的に有効化するようにしてみました。

最初はTDiary::IO::Base#styleの中で定数を探索して必要に応じて有効化すればいいかなと思ったのですが、キャッシュがある時はここを通らずにスタイルクラスが参照されるので、BaseDiaryなどをあらかじめインクルードしておかないとエラーになってしまうようです。

BaseDiaryなどを自動でインクルードするのをやめればもうちょっとすっきりしたコードになると思います。
