### PR TITLE
Use absolute paths to filter files to be required

### DIFF
--- a/plugin/60sf.rb
+++ b/plugin/60sf.rb
@@ -127,7 +127,7 @@ if sf_option( 'selected' ) && !@sf_filters then
 			path = "#{dir}/#{filename}"
 			if File.readable?( path ) then
 				begin
-					require path
+					require File.expand_path( path )
 					@sf_filters << TDiary::Filter::const_get("#{File::basename(filename, ".rb").capitalize}Filter")::new(@cgi, @conf)
 					plugin_path = "#{dir}/plugin/#{filename}"
 					load_plugin(plugin_path) if File.readable?(plugin_path)


### PR DESCRIPTION
tdiary.rbと同じディレクトリにあるtdiary.confのsf.pathに、標準的ではないディレクトリを指定すると、そのなかのファイルをrequireするときに、cannot load such fileをraiseします。フィルターの含まれるディレクトリがインクルードパスに含まれないのが原因と思われます。

このパッチでは、requireの引数を絶対パスにしてこのエラーを回避しています。いかがでしょうか?

50sp.rbでは、ファイルはrequireされずload_plugin内でopenされますのでこの問題は起きなさそうです。
