### PR TITLE
fix the document and add gem 'thor' to Gemfile for PaaS

### DIFF
--- a/doc/INSTALL-paas.md
+++ b/doc/INSTALL-paas.md
@@ -57,7 +57,7 @@ heroku コマンドを用いて Heroku でアプリケーションを作成し�
 日記更新時に必要となるユーザー名とパスワードを保存する .htpasswd ファイルを作成します。この情報は重要なので、外部には公開しないでください。
 
 ```
-% bundle exec rake auth:password:create
+% bundle exec bin/tdiary htpasswd
 ```
 
 ここまでの変更内容を deploy ブランチにコミットし、Heroku にアプリケーションを転送します。

--- a/misc/paas/heroku/Gemfile
+++ b/misc/paas/heroku/Gemfile
@@ -14,6 +14,7 @@ gem 'omniauth-github'
 gem 'thin', require: false
 gem 'tdiary-io-rdb'
 gem 'pg'
+gem 'thor'
 
 # To use memcached for Cache
 # gem 'tdiary-cache-memcached'


### PR DESCRIPTION
herokuを使おうとしたらドキュメントが古いということを[教えていただいた](http://twitter.com/tDiary/status/484514846575063041)ので修正しました。
さらに thor がないと言われたので misc/paas/heroku/Gemfile に thor を追加しておきました。
- Fix the doc/INSTALL-paas.md to use bin/tdiary command
- Add gem 'thor' to Gemfile to deploy to heroku
