### PR TITLE
fixed require_paths in tdiary.gemspec for tdiary-style-gfm, tdiary-style-rd

### DIFF
--- a/tdiary.gemspec
+++ b/tdiary.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["."]
+  spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 1.9.2'
 


### PR DESCRIPTION
#432 の変更により、tdiary-style-gfm, tdiary-style-rd の spec が失敗するようになっていました。

tdiary-style-gfm:

```
% bundle exec rake spec
/usr/bin/ruby2.1 -I/home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib:/home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-support-3.1.0/lib /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/spec/spec_helper.rb:2:in `require': cannot load such file -- tdiary/core_ext (LoadError)
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/spec/spec_helper.rb:2:in `<top (required)>'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/spec/tdiary/style/gfm_spec.rb:2:in `require'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/spec/tdiary/style/gfm_spec.rb:2:in `<top (required)>'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/configuration.rb:1105:in `load'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/configuration.rb:1105:in `block in load_spec_files'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/configuration.rb:1105:in `each'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/configuration.rb:1105:in `load_spec_files'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/runner.rb:96:in `setup'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/runner.rb:84:in `run'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/runner.rb:69:in `run'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/runner.rb:37:in `invoke'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/exe/rspec:4:in `<main>'
/usr/bin/ruby2.1 -I/home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib:/home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-support-3.1.0/lib /home/debian/go/src/github.com/minimum2scp/tdiary-style-gfm/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```

tdiary-style-rd:

```
% bundle exec rake spec
/usr/bin/ruby2.1 -I/home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib:/home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-support-3.1.0/lib /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/spec/spec_helper.rb:2:in `require': cannot load such file -- tdiary/comment_manager (LoadError)
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/spec/spec_helper.rb:2:in `<top (required)>'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/spec/tdiary/style/rd_spec.rb:2:in `require'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/spec/tdiary/style/rd_spec.rb:2:in `<top (required)>'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/configuration.rb:1105:in `load'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/configuration.rb:1105:in `block in load_spec_files'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/configuration.rb:1105:in `each'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/configuration.rb:1105:in `load_spec_files'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/runner.rb:96:in `setup'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/runner.rb:84:in `run'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/runner.rb:69:in `run'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib/rspec/core/runner.rb:37:in `invoke'
    from /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/exe/rspec:4:in `<main>'
/usr/bin/ruby2.1 -I/home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/lib:/home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-support-3.1.0/lib /home/debian/go/src/github.com/minimum2scp/tdiary-style-rd/vendor/bundle/ruby/2.1.0/gems/rspec-core-3.1.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```

tdiary-style-gfm, tdiary-style-rd 以外は確認していませんが、Gemfile で

```
gem 'tdiary', github: 'tdiary/tdiary-core'
```

のように指定しているものは同様に失敗すると思います。

tdiary.gemspec の require_paths を修正することで、
tdiary-style-gfm と tdiary-style-rd の spec が通ることと、
tdiary-core 自身の spec も通ることは確認しました。
