### PR TITLE
change the adding load path to 'lib' in config.ru

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
-$:.unshift( File::dirname( __FILE__ ).untaint )
+$:.unshift( File.join(File::dirname( __FILE__ ), 'lib' ).untaint )
 require 'tdiary/application'
 
 use ::Rack::Reloader unless ENV['RACK_ENV'] == 'production'


### PR DESCRIPTION
"./tdiary/_" が "./lib/tdiary/_" に移動したことに伴った #432 の変更により、付属の config.ru を使って bundle exec rackup などとしたときに require 'tdiary/application' が通らなくなっていました。
#432 に沿って、config.ru も require 'tdiary/application' が通るように load path が '.' ではなく './lib' が追加されるように変更してみました。

今は tDiary gem で運用するので直接影響はないかも知れませんが一応プルリクエストとしてみました。どうするのがよいでしょうか。
