### PR TITLE
fix paths used in the 'tdiary' command

### DIFF
--- a/lib/tdiary/cli.rb
+++ b/lib/tdiary/cli.rb
@@ -8,7 +8,7 @@ module TDiary
 		include Thor::Actions
 
 		def self.source_root
-			File.expand_path('../..', __FILE__)
+			File.expand_path('../../..', __FILE__)
 		end
 
 		desc "new DIR_NAME", "Create a new tDiary directory"

--- a/lib/tdiary/environment.rb
+++ b/lib/tdiary/environment.rb
@@ -5,7 +5,7 @@ module TDiary; end
 module TDiary::Cache; end
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 


### PR DESCRIPTION
tdiary コマンドのサブコマンドの new コマンドと server コマンドのときに中で使われている必要なファイルのパスが https://github.com/tdiary/tdiary-core/pull/432 の変更により ./lib/ 以下を指すようになって動かなくなっていたので修正しました。
(tdiary:master において、rake install した tdiary-4.1.0.20140908.gem の tdiary コマンド)
