### PR TITLE
Use the new beta build env on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
-cache: bundler
+
+sudo: false
 
 services: memcache
 
@@ -12,7 +13,7 @@ rvm:
 cache: bundler
 
 # ignored --deployment option
-bundler_args: "--without server"
+bundler_args: "--without server --deployment --jobs=3 --retry=3"
 
 before_install:
   - "export DISPLAY=:99.0"


### PR DESCRIPTION
caching is only available on the new build env
added --jobs and --retry to bundler install as this installs gems faster
added --deployment back, it is best practice, especially when you have a Gemfile.lock
the new build env has more ram, more cpu, and better network stability
(docs coming soon)
