### PR TITLE
fix #458: error on update running on ruby 1.9.3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2014-12-16  TADA Tadashi <t@tdtds.jp>
+	* plugin/category.rb: fix error on update running on ruby 1.9.3
+
 2014-11-29  TADA Tadashi <t@tdtds.jp>
 	* release 4.1.0
 

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = '4.1.0'
+	VERSION = '4.1.0.20141216'
 end

--- a/misc/plugin/category.rb
+++ b/misc/plugin/category.rb
@@ -423,7 +423,7 @@ class Cache
 	end
 
 	def get(db, cat)
-		JSON.load(db.get(cat))
+		JSON.load(db.get(cat) || '{}')
 	end
 
 	def set(db, cat, data)


### PR DESCRIPTION
ruby 1.9.3内蔵のJSONは、loadにnilが渡されるとエラーになる。これを避けるためのコードを入れた。
