### PR TITLE
fix load path for full package

### DIFF
--- a/spec/core/tdiary_spec.rb
+++ b/spec/core/tdiary_spec.rb
@@ -13,8 +13,18 @@ describe TDiary do
     end
 
     context 'append gem' do
+      before do
+        FileUtils.mkdir_p @root_path + '/misc/lib/foo-0.0.1/lib'
+        load @root_path + '/lib/tdiary.rb'
+        @loaded_paths = $LOAD_PATH.map{|path| File.expand_path(path)}
+      end
+
       it "include append gem path into load path" do
         expect(@loaded_paths).to be_include @root_path + '/misc/lib/foo-0.0.1/lib'
+      end
+
+      after do
+        FileUtils.rm_rf @root_path + '/misc/lib/foo-0.0.1'
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,18 +17,11 @@ if ENV['COVERAGE'] = 'simplecov'
 	end
 end
 
-# need to prepare before require 'tdiary'
-FileUtils.mkdir_p File.expand_path(File.dirname(__FILE__) + '/..') + '/misc/lib/foo-0.0.1/lib'
-
 require 'tdiary'
 
 RSpec.configure do |config|
 	config.expect_with :rspec do |c|
 		c.syntax = :expect
-	end
-
-	config.after(:suite) do
-		FileUtils.rm_rf File.expand_path(File.dirname(__FILE__) + '/..') + '/misc/lib/foo-0.0.1'
 	end
 end
 


### PR DESCRIPTION
https://github.com/tdiary/tdiary-core/issues/457 の修正です。`$:` に入れる misc/lib(パッケージ用のディレクトリ)のパスが誤っていたため full パッケージ等で利用できない問題を修正しています。

この変更で misc/lib/foo-x.y.z/lib というディレクトリが $: に追加されていることを確認済みです。
