### PR TITLE
DoS-resistant

### DIFF
--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -38,7 +38,13 @@ module TDiary
 		end
 
 		def call( env )
-			@app.call( env )
+			begin
+				@app.call( env )
+			rescue Exception => e
+				body = ["#{e.class}: #{e}\n"]
+				body << e.backtrace.join("\n")
+				[500, {'Content-Type' => 'text/plain'}, body]
+			end
 		end
 	end
 

--- a/spec/core/application_spec.rb
+++ b/spec/core/application_spec.rb
@@ -40,6 +40,24 @@ describe TDiary::Application do
 				end
 			end
 		end
+
+		context "when the application raises exception" do
+			before do
+				TDiary::Application.configure do
+					config.builder do
+						map '/cause_exception' do
+							run lambda {|env| raise StandardError.new }
+						end
+					end
+				end
+			end
+
+			it do
+				get '/cause_exception'
+				expect(last_response.status).to eq 500
+				expect(last_response.body).to match(/^StandardError/)
+			end
+		end
 	end
 end
 

--- a/spec/core/application_spec.rb
+++ b/spec/core/application_spec.rb
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+require 'rack/test'
+require 'tdiary/application'
+
+describe TDiary::Application do
+	include Rack::Test::Methods
+
+	before do
+	end
+
+	describe '#call' do
+		let(:app) { TDiary::Application.new }
+
+		context "when is accessed to index"
+		it do
+			get '/'
+			expect(last_response.status).to eq 200
+		end
+
+		context "when is accessed to update" do
+			it do
+				get '/update.rb'
+				expect(last_response.status).to eq 401
+			end
+		end
+
+		context "with base_dir" do
+			let(:app) { TDiary::Application.new('/diary') }
+
+			it do
+				get '/diary/'
+				expect(last_response.status).to eq 200
+			end
+
+			context "when access to root directory" do
+				it do
+					get '/'
+					expect(last_response.status).to eq 404
+				end
+			end
+		end
+	end
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:


### PR DESCRIPTION
#402 で指摘されたDos攻撃への対応です。TDiary::Application#callにて例外が発生した場合に、ステータスコード500を返します。

> あと、Dispatcherなどの層で例外が起きるとプロセスが落ちてしまうのはそういうものでしょうか。CGIの頃はそれでよかったと思うのですが、unicornなどでの運用だと潜在的なDoS攻撃リスクという意味でちょっと不安かなと思いました。具体的に他にまずいケースというのは思い付いてはないのですが。

もう一つの問題（不正な文字列への対応）もこのPRで合わせて対応します。

> 例外が起きているのはDispatcherでRackCGI.newしているところなので、RackCGI.newにブロックを渡してエンコーディング変換をする形が自然かなと思います。