### PR TITLE
tdiary serverコマンドにlogオプションを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,6 @@ group :coffee do
 end
 
 group :server do
-  platforms :mri do
-    gem 'thin'
-  end
-
   platforms :jruby do
     gem 'trinidad'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -11,12 +11,6 @@ group :coffee do
   gem 'therubyracer'
 end
 
-group :server do
-  platforms :jruby do
-    gem 'trinidad'
-  end
-end
-
 group :development do
   gem 'pit', require: false
   gem 'racksh', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,11 +26,9 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor (= 1.2.2)
       thor (= 0.18.1)
-    daemons (1.1.9)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    eventmachine (1.0.4)
     execjs (2.2.2)
     fastimage (1.6.6)
       addressable (~> 2.3, >= 2.3.5)
@@ -112,10 +110,6 @@ GEM
     therubyracer (0.12.1)
       libv8 (~> 3.16.14.0)
       ref
-    thin (1.6.3)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0)
-      rack (~> 1.0)
     thor (0.18.1)
     tilt (1.4.1)
     tins (0.13.2)
@@ -149,5 +143,4 @@ DEPENDENCIES
   sqlite3
   test-unit
   therubyracer
-  thin
   trinidad

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,4 +143,3 @@ DEPENDENCIES
   sqlite3
   test-unit
   therubyracer
-  trinidad

--- a/lib/tdiary/tasks/release.rake
+++ b/lib/tdiary/tasks/release.rake
@@ -34,7 +34,7 @@ def make_tarball( repo, version = nil )
 			sh "chmod +x index.rb index.fcgi update.rb update.fcgi"
 			sh 'rake doc'
 			Bundler.with_clean_env do
-					sh "bundle --path .bundle --without coffee:server:development:test"
+					sh "bundle --path .bundle --without coffee:development:test"
 			end
 			Dir.chdir '.bundle/ruby' do
 				v = `ls`.chomp


### PR DESCRIPTION
#397 の対応です。標準のRackサーバをwebrickにし、logオプションを追加しました。未指定時はこれまで通りに標準出力に表示します。