### PR TITLE
パッケージ版のファイルサイズを削減

### DIFF
--- a/lib/tdiary/tasks/release.rake
+++ b/lib/tdiary/tasks/release.rake
@@ -36,6 +36,17 @@ def make_tarball( repo, version = nil )
 			Bundler.with_clean_env do
 					sh "bundle --path .bundle --without coffee:server:development:test"
 			end
+
+			# reduce filesize
+			Dir.glob('.bundle/ruby/*/cache/*').each do |file|
+				# cached gem file
+				rm_rf file
+			end
+			Dir.glob('.bundle/ruby/*/gems/*/*/').each do |dir|
+				# spec, fixtures etc..
+				rm_rf dir unless File.basename(dir).match(/lib|data/)
+			end
+
 			Dir.chdir '.bundle/ruby' do
 				v = `ls`.chomp
 				case v


### PR DESCRIPTION
パッケージ版のファイルサイズが50MB弱となっていて、その多くを同梱のgemが占めています。不要なファイルをパッケージから除くことで、ファイルサイズを削減します。

 * `.bundle/ruby/*/cache/` に含まれるgemファイル
 * 各gemの lib, data 以外のディレクトリ

これにより、ファイルサイズが基本セットで2MB, フルセットで6MB程度となります。

実際には、`gems/gemoji-2.1.0/images/emoji/unicode` と `gems/fastimage-1.6.6/test/fixtures`がサイズの大部分を占めるので、ここだけ狙い撃ちで消しても効果あると思います。gemojiライブラリは絵文字有無の判定だけで使っているようなので、imagesディレクトリは使っていません。