### PR TITLE
fix makerss.path (makerss.rb knows document root)

### DIFF
--- a/spec/fixtures/tdiary.conf.gem
+++ b/spec/fixtures/tdiary.conf.gem
@@ -38,8 +38,8 @@ recent_list.rb
 "
 
 @options['dropdown_calendar.label'] = ''
-@options['makerss.file'] = 'public/index.rdf'
-@options['makerss.no_comments.file'] = 'public/no_comments.rdf'
+@options['makerss.file'] = 'index.rdf'
+@options['makerss.no_comments.file'] = 'no_comments.rdf'
 
 @options['spamfilter.bad_comment_patts'] = "(href=|casino|gambling|betting|fastsearch\\.eu\\.com|ganzao|poker|holdem|hold.em|roulette|drug|tramadol|viagra|fioricet|oxycontin|biaxin|aldara|business cards|home depot|slot.?machine|insurance|getblog2|video-game|Good site|internet-all\\.com|deai|tdfms|comu2|omaha)\r\n"
 @options['spamfilter.bad_ip_addrs'] = ""

--- a/spec/fixtures/tdiary.conf.rack
+++ b/spec/fixtures/tdiary.conf.rack
@@ -38,8 +38,8 @@ recent_list.rb
 "
 
 @options['dropdown_calendar.label'] = ''
-@options['makerss.file'] = 'public/index.rdf'
-@options['makerss.no_comments.file'] = 'public/no_comments.rdf'
+@options['makerss.file'] = 'index.rdf'
+@options['makerss.no_comments.file'] = 'no_comments.rdf'
 
 @options['spamfilter.bad_comment_patts'] = "(href=|casino|gambling|betting|fastsearch\\.eu\\.com|ganzao|poker|holdem|hold.em|roulette|drug|tramadol|viagra|fioricet|oxycontin|biaxin|aldara|business cards|home depot|slot.?machine|insurance|getblog2|video-game|Good site|internet-all\\.com|deai|tdfms|comu2|omaha)\r\n"
 @options['spamfilter.bad_ip_addrs'] = ""

--- a/spec/fixtures/tdiary.conf.secure
+++ b/spec/fixtures/tdiary.conf.secure
@@ -37,8 +37,8 @@ my-ex.rb
 "
 
 @options['dropdown_calendar.label'] = ''
-@options['makerss.file'] = 'public/index.rdf'
-@options['makerss.no_comments.file'] = 'public/no_comments.rdf'
+@options['makerss.file'] = 'index.rdf'
+@options['makerss.no_comments.file'] = 'no_comments.rdf'
 
 @options['spamfilter.bad_comment_patts'] = "(href=|casino|gambling|betting|fastsearch\\.eu\\.com|ganzao|poker|holdem|hold.em|roulette|drug|tramadol|viagra|fioricet|oxycontin|biaxin|aldara|business cards|home depot|slot.?machine|insurance|getblog2|video-game|Good site|internet-all\\.com|deai|tdfms|comu2|omaha)\r\n"
 @options['spamfilter.bad_ip_addrs'] = ""

--- a/spec/fixtures/tdiary.conf.webrick
+++ b/spec/fixtures/tdiary.conf.webrick
@@ -39,8 +39,8 @@ recent_list.rb
 "
 
 @options['dropdown_calendar.label'] = ''
-@options['makerss.file'] = 'public/index.rdf'
-@options['makerss.no_comments.file'] = 'public/no_comments.rdf'
+@options['makerss.file'] = 'index.rdf'
+@options['makerss.no_comments.file'] = 'no_comments.rdf'
 
 @options['spamfilter.bad_comment_patts'] = "(href=|casino|gambling|betting|fastsearch\\.eu\\.com|ganzao|poker|holdem|hold.em|roulette|drug|tramadol|viagra|fioricet|oxycontin|biaxin|aldara|business cards|home depot|slot.?machine|insurance|getblog2|video-game|Good site|internet-all\\.com|deai|tdfms|comu2|omaha)\r\n"
 @options['spamfilter.bad_ip_addrs'] = ""


### PR DESCRIPTION
spec/fixturesディレクトリ内のtdiary.confにて、@options['makerss.file']のパスに不要なpublicがついていたので直しました。`public/public/index.rdf` にフィードが出力される設定になっていました。
（テストでも使っていないので、特に実害はないのですが）