### PR TITLE
fix broken assets_copy command

### DIFF
--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -64,9 +64,7 @@ module TDiary
 
 			map Application.config.path[:assets] do
 				environment = Sprockets::Environment.new
-				TDiary::Extensions::constants.map {|extension|
-					TDiary::Extensions::const_get( extension ).assets_path
-				}.flatten.uniq.each {|assets_path|
+				TDiary::Application.config.assets_paths.each {|assets_path|
 					environment.append_path assets_path
 				}
 

--- a/lib/tdiary/application/configuration.rb
+++ b/lib/tdiary/application/configuration.rb
@@ -1,7 +1,7 @@
 module TDiary
 	class Application
 		class Configuration
-			attr_accessor :assets_paths, :assets_precompile, :plugin_paths, :path, :builder_procs, :authenticate_proc
+			attr_accessor :assets_precompile, :plugin_paths, :path, :builder_procs, :authenticate_proc
 
 			def initialize
 				# if you need to auto compilation for CoffeeScript
@@ -22,6 +22,12 @@ module TDiary
 
 			def authenticate(middleware, *params, &block)
 				@authenticate_proc = proc { use middleware, *params, &block }
+			end
+
+			def assets_paths
+				TDiary::Extensions::constants.map {|extension|
+					TDiary::Extensions::const_get( extension ).assets_path
+				}.flatten.uniq.each
 			end
 		end
 	end

--- a/lib/tdiary/cli.rb
+++ b/lib/tdiary/cli.rb
@@ -58,7 +58,7 @@ module TDiary
 
 		desc "assets_copy", "copy assets files"
 		def assets_copy
-			require 'tdiary/environment'
+			require 'tdiary'
 			assets_path = File.join(TDiary.server_root, 'public/assets')
 			TDiary::Application.config.assets_paths.each do |path|
 				Dir.glob(File.join(path, '*')).each do |entity|


### PR DESCRIPTION
assetsパスの読み込み方法の変更 (#375) によりbin/tdiaryのassets_copyコマンドが動かなくなっていました。

```
$ bundle exec bin/tdiary assets_copy
/Users/machu/work/tdiary/tdiary-core/lib/tdiary/cli.rb:63:in `assets_copy': undefined method `each' for nil:NilClass (NoMethodError)
        from /Users/machu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from /Users/machu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from /Users/machu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
        from /Users/machu/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
        from bin/tdiary:7:in `<main>'
```