### PR TITLE
個別記事でのog:imageのlinkがおかしい？

### DIFF
--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -347,7 +347,7 @@ def default_ogp
 		end
 		%Q[<meta content="#{title_tag.gsub(/<[^>]*>/, "")}" property="og:title">
 		<meta content="#{(@mode == 'day') ? 'article' : 'website'}" property="og:type">
-		<meta content="#{h uri}#{h theme_url}/ogimage.png" property="og:image">
+		<meta content="#{base_url}images/ogimage.png" property="og:image">
 		<meta content="#{h uri}" property="og:url">]
 	end
 end


### PR DESCRIPTION
logwatchに
```
    404 Not Found
       /d/20030317.htmltheme/ogimage.png: 1 Time(s)
       /d/20030921.htmltheme/ogimage.png: 1 Time(s)
       /d/20070211.htmltheme/ogimage.png: 1 Time(s)
```
というものが多量に出るので探してみたところ、個別記事中に
```html
		<meta content="article" property="og:type">
		<meta content="http://XXX/d/20150124.htmltheme/ogimage.png" property="og:image">
		<meta content="http://XXX/d/20150124.html" property="og:url">
```
という存在しないリンクが生成されていました。トップページの場合は
```html
		<meta content="website" property="og:type">
		<meta content="http://XXX/d/theme/ogimage.png" property="og:image">
		<meta content="http://XXX/d/" property="og:url">
```
となっており正常のように見えます。
https://github.com/tdiary/tdiary-core/blob/v4.1.1/lib/tdiary/plugin/00default.rb#L350
で個別記事のURIのうしろにそのままogimage.pngを付与しているのが問題のように見えたので、個別記事でもトップページ同様に単一のURIを設定するようにしてみましたが、これで認識は合っているでしょうか？