### PR TITLE
use Rack::Session::Dalli automatically if dalli gem loaded

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2015-01-28  TADA Tadashi <t@tdtds.jp>
+	* use Rack::Session::Dalli automatically if dalli gem loaded
+
 2015-01-27  TADA Tadashi <t@tdtds.jp>
 	* plugin/00default.rb: fix #482 by another code: bad url of og:image
 

--- a/lib/tdiary/application/extensions/omniauth.rb
+++ b/lib/tdiary/application/extensions/omniauth.rb
@@ -1,10 +1,18 @@
 # -*- coding: utf-8 -*-
 require 'tdiary/application'
 require 'tdiary/rack/auth/omniauth'
+begin
+	require 'rack/session/dalli'
+rescue LoadError
+end
 
 TDiary::Application.configure do
 	config.builder do
-		use ::Rack::Session::Pool, expire_after: 2592000
+		if ::Rack::Session.const_defined? :Dalli
+			use ::Rack::Session::Dalli, cache: Dalli::Client.new, expire_after: 2592000
+		else
+			use ::Rack::Session::Pool, expire_after: 2592000
+		end
 		use OmniAuth::Builder do
 			configure {|conf| conf.path_prefix = "/auth" }
 			provider :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']


### PR DESCRIPTION
`Gemfile.local`にDalli gemがある場合に、セッションのストアを自動的に`Rack::Session::Dalli`にする。これでpumaやunicornを使った複数サーバを簡単に構築できるようになる。

他のストア候補がある場合には別解が必要だけど、編集用のセッションはそんなに永続的でなくてよいので、とりあえずmemcacheを使うのはアリかな、と。