### PR TITLE
enable to specify multiple twitter user in OmniAuth

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2015-02-19  TADA Tadashi <t@tdtds.jp>
+	* enable to specify multiple twitter user in OmniAuth
+
 2015-02-02  TADA Tadashi <t@tdtds.jp>
 	* Gemfile: work around about rack 1.6 not separate params with ';'. see #485
 

--- a/lib/tdiary/application/extensions/omniauth.rb
+++ b/lib/tdiary/application/extensions/omniauth.rb
@@ -23,7 +23,6 @@ TDiary::Application.configure do
 	end
 
 	config.authenticate TDiary::Rack::Auth::OmniAuth, :twitter do |auth|
-		# TODO: an user can setting
-		auth.info.nickname == ENV['TWITTER_NAME']
+		ENV['TWITTER_NAME'].split(/,/).include?(auth.info.nickname)
 	end
 end


### PR DESCRIPTION
Twitter認証にしたとき、編集可能なユーザを複数指定したかったのでカンマ区切りでいけるようにしてみた。