### PR TITLE
fix bug: doesn't start on webrick

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
-$:.unshift( File.join(File::expand_path(File::dirname( __FILE__ ), 'lib' )).untaint )
+$:.unshift( File.join(File::expand_path(File::dirname( __FILE__ )), 'lib' ).untaint )
 require 'tdiary/application'
 
 use ::Rack::Reloader unless ENV['RACK_ENV'] == 'production'


### PR DESCRIPTION
webrick環境でtDiaryが起動できなくなっています。

```
$ bundle exec rackup
/Users/machu/work/tdiary/tdiary-core/config.ru:2:in `require': cannot load such file -- tdiary/application (LoadError)
        from /Users/machu/work/tdiary/tdiary-core/config.ru:2:in `block in <main>'
```

#483 で `File::expand_path` を使うように変更していますが、第1引数がすでに絶対パスだった場合に、 lib ディレクトリが join されないのが原因です。expand_pathのあとにjoinすることで、webrick, unicorn環境ともに起動できるようになりました。

unicornとpumaの環境で #483 の問題が起きていたのは、 `__FILE__` が相対パスか絶対パスかの違いだったのですね。

## unicorn環境

```ruby
__FILE__
=> 'config.ru'
File.join(File::expand_path(File::dirname( __FILE__ ), 'lib' ))
=> '/Users/machu/work/tdiary/tdiary-core/lib'
File.join(File::expand_path(File::dirname( __FILE__ )), 'lib' )
=> '/Users/machu/work/tdiary/tdiary-core/lib'
```

## webrick環境

```ruby
__FILE__
=> '/Users/machu/work/tdiary/tdiary-core/config.ru'
File.join(File::expand_path(File::dirname( __FILE__ ), 'lib' ))
=> '/Users/machu/work/tdiary/tdiary-core'
File.join(File::expand_path(File::dirname( __FILE__ )), 'lib' )
=> '/Users/machu/work/tdiary/tdiary-core/lib'
```
