### PR TITLE
catch TDiary::ForceRedirect exception from 90migrate.rb at startup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2015-05-05  MATSUOKA Kohei <kohei@machu.jp>
+	* catch TDiary::ForceRedirect exception from 90migrate.rb at startup
+
 2015-04-22  TADA Tadashi <t@tdtds.jp>
 	* add full path of lib into LOAD_PATH, fix #481 #483
 

--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -80,22 +80,27 @@ module TDiary
 			tdiary = TDiary::TDiaryBase.new(cgi, '', conf)
 			io = conf.io_class.new(tdiary)
 
-			plugin = TDiary::Plugin.new(
-				'conf' => conf,
-				'mode' => 'startup',
-				'diaries' => tdiary.diaries,
-				'cgi' => cgi,
-				'years' => nil,
-				'cache_path' => io.cache_path,
-				'date' => Time.now,
-				'comment' => nil,
-				'last_modified' => Time.now,  # FIXME
-				'logger' => TDiary.logger,
-				# 'debug' => true
-			)
+			begin
+				plugin = TDiary::Plugin.new(
+					'conf' => conf,
+					'mode' => 'startup',
+					'diaries' => tdiary.diaries,
+					'cgi' => cgi,
+					'years' => nil,
+					'cache_path' => io.cache_path,
+					'date' => Time.now,
+					'comment' => nil,
+					'last_modified' => Time.now,  # FIXME
+					'logger' => TDiary.logger,
+					# 'debug' => true
+				)
 
-			# run startup plugin
-			plugin.__send__(:startup_proc, self)
+				# run startup plugin
+				plugin.__send__(:startup_proc, self)
+			rescue TDiary::ForceRedirect => e
+				# 90migrate.rb raises TDiary::ForceRedirect at first startup
+				TDiary::logger.warn(e)
+			end
 		end
 	end
 end

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = '4.1.2'
+	VERSION = '4.1.2.20150505'
 end


### PR DESCRIPTION
tDiaryの初回起動時に、以下の例外が発生して起動に失敗します。

```
(plugin/90migrate.rb):101:in `block in load_plugin': TDiary::ForceRedirect (TDiary::ForceRedirect)
        from /Users/machu/work/tdiary/tdiary-core/lib/tdiary/plugin.rb:91:in `instance_eval'
        from /Users/machu/work/tdiary/tdiary-core/lib/tdiary/plugin.rb:91:in `block in load_plugin'
        from /Users/machu/work/tdiary/tdiary-core/lib/tdiary/plugin.rb:90:in `open'
        from /Users/machu/work/tdiary/tdiary-core/lib/tdiary/plugin.rb:90:in `load_plugin'
        from /Users/machu/work/tdiary/tdiary-core/lib/tdiary/plugin.rb:70:in `block in initialize'
        from /Users/machu/work/tdiary/tdiary-core/lib/tdiary/plugin.rb:68:in `each'
        from /Users/machu/work/tdiary/tdiary-core/lib/tdiary/plugin.rb:68:in `initialize'
        from /Users/machu/work/tdiary/tdiary-core/lib/tdiary/application.rb:83:in `new'
        from /Users/machu/work/tdiary/tdiary-core/lib/tdiary/application.rb:83:in `run_plugin_startup_procs'
        from /Users/machu/work/tdiary/tdiary-core/lib/tdiary/application.rb:59:in `initialize'
```

#474 にてサーバ起動時にプラグインを動かすようにしましたが、セットアップ直後の初回起動時は90migrate.rbが動き、 `TDiary::ForceRedirect` 例外が発生するためです。2回目からの起動では発生しません。

ということで、この例外を無視するようにしました。