### PR TITLE
bundle update (term-ansicolor 1.3.1 is yanked)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     sprockets (3.2.0)
       rack (~> 1.0)
     sqlite3 (1.3.10)
-    term-ansicolor (1.3.1)
+    term-ansicolor (1.3.2)
       tins (~> 1.0)
     test-unit (3.1.2)
       power_assert


### PR DESCRIPTION
bundle install fails as follows:

```
% bundle install --path vendor/bundle --jobs=4 --frozen 
Warning: the running version of Bundler is older than the version that created the lockfile. We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Fetching gem metadata from https://rubygems.org/.........
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Could not find term-ansicolor-1.3.1 in any of the sources
```

term-ansicolor 1.3.1 is yanked.
