### PR TITLE
bundle update (libv8 3.16.14.9 is yanked)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     execjs (2.5.2)
     fastimage (1.7.0)
       addressable (~> 2.3, >= 2.3.5)
-    ffi (1.9.9)
+    ffi (1.9.10)
     gemoji (2.1.0)
     hikidoc (0.1.0)
     http-cookie (1.0.2)
@@ -44,7 +44,7 @@ GEM
     jasmine-core (2.3.4)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.9)
+    libv8 (3.16.14.11)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
@@ -96,7 +96,7 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    sequel (4.23.0)
+    sequel (4.24.0)
     simplecov (0.9.2)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
@@ -136,7 +136,6 @@ DEPENDENCIES
   launchy
   mail
   pit
-  pry
   pry-byebug
   rack
   racksh


### PR DESCRIPTION
bundle install fails as follows:

```
% bundle install --path vendor/bundle --jobs=4 --frozen
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

If this is a development machine, remove the Gemfile freeze 
by running `bundle install --no-deployment`.

You have deleted from the Gemfile:
* pry
% git status
On branch master
Your branch is up-to-date with 'origin/master'.
nothing to commit, working directory clean
% bundle config --delete frozen
% bundle install --path vendor/bundle --jobs=4         
Fetching gem metadata from https://rubygems.org/.........
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies...
Could not find libv8-3.16.14.9 in any of the sources
```

libv8 3.16.14.9 is yanked.
