### PR TITLE
fix invalid HTML when use 'thumbsup' emoji in comment

### DIFF
--- a/lib/tdiary/core_ext.rb
+++ b/lib/tdiary/core_ext.rb
@@ -43,7 +43,7 @@ class String
 			if emoji_alias == 'plus1' or emoji_alias == '+1'
 				emoji_url % (['plus1']*3)
 			elsif emoji = Emoji.find_by_alias(emoji_alias)
-				emoji_url % ([emoji.name]*3)
+				emoji_url % ([CGI.escape(emoji.name)]*3)
 			else
 				match
 			end

--- a/spec/core/core_ext_spec.rb
+++ b/spec/core/core_ext_spec.rb
@@ -47,6 +47,13 @@ describe "core extension library" do
 			end
 		end
 
+		context "thumbsupでもemojify" do
+			before { @result = "いいね!:thumbsup:".emojify }
+			it do
+				expect(@result).to eq "いいね!<img src='http://www.emoji-cheat-sheet.com/graphics/emojis/%2B1.png' width='20' height='20' title='%2B1' alt='%2B1' class='emoji' />"
+			end
+		end
+
 		context "絵文字に変換しない" do
 			[
 				":<script type='text/javascript'></script>: は美味しい",


### PR DESCRIPTION
* ツッコミで絵文字「thumbsup」を使う
* Emojiライブラリが「thumbsup」のaliasとして「+1」を返す
* 「+」がエスケープされていないので正しいURLにならず、404

HTML展開のテンプレートでCGI.escapeをするように修正。外部入力をそのまま使うわけではないので、セキュリティ要素はありません。