### PR TITLE
explicitly eval tdiary.conf without binding

### DIFF
--- a/lib/tdiary/configuration.rb
+++ b/lib/tdiary/configuration.rb
@@ -138,7 +138,7 @@ module TDiary
 			@secure = true unless @secure
 			@options = {}
 
-			eval( File::open( 'tdiary.conf' ) {|f| f.read }.untaint, b, "(tdiary.conf)", 1 )
+			eval( File::open( 'tdiary.conf' ) {|f| f.read }.untaint, nil, "(tdiary.conf)", 1 )
 
 			# language setup
 			@lang = 'ja' unless @lang


### PR DESCRIPTION
ソースを読んでいて、Configure#configure_attrsで未初期化の変数bをevalに与えているのが気になりました。
