### PR TITLE
Use Timeout.timeout instead of Object#timeout

### DIFF
--- a/lib/tdiary/filter/spam.rb
+++ b/lib/tdiary/filter/spam.rb
@@ -165,7 +165,7 @@ module TDiary
 			end
 
 			def lookup(domain, dnsbl, iplookup = false)
-				timeout(5) do
+				Timeout::timeout(5) do
 					domain = IPSocket::getaddress( domain ).split(/\./).reverse.join(".") if iplookup
 					address = Resolv.getaddress( "#{domain}.#{dnsbl}" )
 					debug("lookup:#{domain}.#{dnsbl} address:#{address}: spam host.")

--- a/misc/plugin/amazon/amazonimg.rb
+++ b/misc/plugin/amazon/amazonimg.rb
@@ -65,7 +65,7 @@ def amazon_call_ecs( asin, country = nil )
 	url << "&ResponseGroup=Medium"
 	url << "&Version=#{@amazon_require_version}"
 
-	timeout( 10 ) do
+	Timeout::timeout( 10 ) do
 		open( url, proxy: @proxy ) {|f| f.read}
 	end
 end

--- a/misc/plugin/ping.rb
+++ b/misc/plugin/ping.rb
@@ -40,7 +40,7 @@ def ping( list )
 		next unless u.host
 		threads << Thread.start( u, xml ) do |u, xml|
 			begin
-				timeout( @conf['ping.timeout'].to_i ) do
+				Timeout::timeout( @conf['ping.timeout'].to_i ) do
 					Net::HTTP.start( u.host, u.port ) do |http|
 						http.post( u.path, xml, 'Content-Type' => 'text/xml' )
 					end

--- a/misc/plugin/recent_rss.rb
+++ b/misc/plugin/recent_rss.rb
@@ -76,6 +76,7 @@ class InvalidResourceError < StandardError; end
 class RSSNotModified < StandardError; end
 
 require 'time'
+require 'timeout'
 require 'net/http'
 require 'uri/generic'
 require 'rss/parser'
@@ -150,7 +151,7 @@ def recent_rss_fetch_rss(uri, cache_time)
 	px_host, px_port = (@conf['proxy'] || '').split( /:/ )
 	px_port = 80 if px_host and !px_port
 	begin
-		timeout( 10 ) do
+		Timeout::timeout( 10 ) do
 			res = Net::HTTP::Proxy( px_host, px_port ).get_response( uri )
 			case res
 			when Net::HTTPSuccess

--- a/misc/plugin/weather.rb
+++ b/misc/plugin/weather.rb
@@ -310,7 +310,7 @@ class Weather
 		@error = nil
 
 		begin
-			timeout( WAITTIME ) do
+			Timeout::timeout( WAITTIME ) do
 				d = @conf.to_native( fetch( url, MAXREDIRECT, header ) )
 				parse_html( d, items )
 			end


### PR DESCRIPTION
Ruby 2.3.0 から以下の警告が出るようになったので ```Timeout.timeout``` を明示して使うようにします

```sh
tdiary-core/lib/tdiary/filter/spam.rb:168:in `lookup': Object#timeout is deprecated, use Timeout.timeout instead.
```