### PR TITLE
サーバサイドでスマートフォン用のページ生成をやめる

### DIFF
--- a/js/amazon.js
+++ b/js/amazon.js
@@ -1,43 +1,13 @@
 /*
- * amazon.js : replace amazon URL using bit.ly (amzn.to).
+ * amazon.js :
+ *   * remove height / width infomation of images
  *
- * Copyright (C) 2011 by TADA Tadashi <t@tdtds.jp>
+ * Copyright (C) 2015 by TADA Tadashi <t@tdtds.jp>
  * You can distribute it under GPL2 or any later version.
  */
 
 $(function(){
-	function shorten(link){
-		var url = link.attr('href');
-		var api = 'http://api.bit.ly/v3/shorten'
-				+ '?format=json'
-				+ '&longUrl=' + encodeURIComponent(url)
-				+ '&login=' + $tDiary.plugin.bitly.login
-				+ '&apiKey=' + $tDiary.plugin.bitly.apiKey;
-
-		$.ajax({
-			type: 'GET',
-			url: api,
-			dataType: 'jsonp',
-			success: function(data){
-				if (data['data']){
-					link.attr('href',data['data']['url']);
-				}
-				else{
-					//console.warn('fail to short: ' + link.attr('href'));
-				}
-			}
-		});
+	if($(window).width() <= 360) {
+		$('img.amazon').attr('height', null).attr('width', null);
 	}
-
-	$(window).bind('scroll', function(event){
-		var bottom = $(window).height() + $(window).scrollTop();
-		//console.warn('window.bottom: ' + bottom);
-		$('a[href*="://www.amazon.co.jp/"]').each(function(){
-			var a = $(this);
-			if (bottom > a.offset().top){
-				//console.warn('appear!: ' + a.text());
-				shorten(a);
-			}
-		});
-	});
 });

--- a/js/amazon_bitly.js
+++ b/js/amazon_bitly.js
@@ -1,0 +1,43 @@
+/*
+ * amazon_bitly.js : replace amazon URL using bit.ly (amzn.to).
+ *
+ * Copyright (C) 2011 by TADA Tadashi <t@tdtds.jp>
+ * You can distribute it under GPL2 or any later version.
+ */
+
+$(function(){
+	function shorten(link){
+		var url = link.attr('href');
+		var api = 'http://api.bit.ly/v3/shorten'
+				+ '?format=json'
+				+ '&longUrl=' + encodeURIComponent(url)
+				+ '&login=' + $tDiary.plugin.bitly.login
+				+ '&apiKey=' + $tDiary.plugin.bitly.apiKey;
+
+		$.ajax({
+			type: 'GET',
+			url: api,
+			dataType: 'jsonp',
+			success: function(data){
+				if (data['data']){
+					link.attr('href',data['data']['url']);
+				}
+				else{
+					//console.warn('fail to short: ' + link.attr('href'));
+				}
+			}
+		});
+	}
+
+	$(window).bind('scroll', function(event){
+		var bottom = $(window).height() + $(window).scrollTop();
+		//console.warn('window.bottom: ' + bottom);
+		$('a[href*="://www.amazon.co.jp/"]').each(function(){
+			var a = $(this);
+			if (bottom > a.offset().top){
+				//console.warn('appear!: ' + a.text());
+				shorten(a);
+			}
+		});
+	});
+});

--- a/lib/tdiary/configuration.rb
+++ b/lib/tdiary/configuration.rb
@@ -45,9 +45,9 @@ module TDiary
 			false
 		end
 
-		# backword compatibility, you can use @cgi.smartphone?
+		# backword compatibility, returns NOT smartphone always
 		def smartphone?
-			@request.smartphone?
+			false
 		end
 		alias iphone? smartphone?
 

--- a/lib/tdiary/core_ext.rb
+++ b/lib/tdiary/core_ext.rb
@@ -9,8 +9,9 @@ module TDiary
 			false
 		end
 
+		# backword compatibility, returns NOT smartphone always
 		def smartphone?
-			self.user_agent =~ /iPhone|iPod|Opera Mini|Android.*Mobile|NetFront|PSP/
+			false
 		end
 	end
 end

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -206,6 +206,7 @@ add_header_proc do
 	<<-HEADER
 	<meta http-equiv="Content-Type" content="text/html; charset=#{h charset}">
 	<meta name="generator" content="tDiary #{h TDIARY_VERSION}">
+	<meta name="viewport" content="width=device-width,initial-scale=1">
 	#{last_modified_header}
 	#{content_script_type}
 	#{author_name_tag}
@@ -217,7 +218,6 @@ add_header_proc do
 	#{jquery_tag.chomp}
 	#{script_tag.chomp}
 	#{css_tag.chomp}
-	#{smartphone_tag.chomp}
 	#{title_tag.chomp}
 	#{robot_control.chomp}
 	HEADER
@@ -417,21 +417,6 @@ def css_tag
 	<link rel="stylesheet" href="#{h theme_url}/base.css" type="text/css" media="all">
 	<link rel="stylesheet" href="#{h css}" title="#{h title}" type="text/css" media="all">
 	CSS
-end
-
-def smartphone_tag
-	if @cgi.smartphone? then
-	<<-CSS
-<meta name = "viewport" content = "width = device-width">
-	<style type="text/css"><!--
-	form.comment textarea {
-		width: 80%;
-	}
-	--></style>
-	CSS
-	else
-		''
-	end
 end
 
 def robot_control

--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -210,7 +210,7 @@ def amazon_to_html( item, with_image = true, label = nil, pos = 'amazon' )
 		unless image[:src] then
 			img = ''
 		else
-			size = @cgi.smartphone? ? '' : %Q|height="#{h image[:height]}" width="#{h image[:width]}"|
+			size = %Q|height="#{h image[:height]}" width="#{h image[:width]}"|
 			img = <<-HTML
 			<img class="#{h pos}" src="#{h image[:src]}"
 			#{size} alt="#{h alt}">

--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -39,8 +39,10 @@ autoload :REXML,   'rexml/document'
   'us' => 'http://rpaproxy.tdiary.org/rpaproxy/us/',
 }
 
+enable_js( 'amazon.js' )
+
 if @conf['amazon.bitly'] and @conf['bitly.login'] and @conf['bitly.key'] then
-	enable_js( 'amazon.js' )
+	enable_js( 'amazon_bitly.js' )
 	add_js_setting( '$tDiary.plugin.bitly' )
 	add_js_setting( '$tDiary.plugin.bitly.login', "'#{@conf['bitly.login']}'" )
 	add_js_setting( '$tDiary.plugin.bitly.apiKey', "'#{@conf['bitly.key']}'" )

--- a/misc/plugin/image.rb
+++ b/misc/plugin/image.rb
@@ -73,9 +73,7 @@ def image( id, alt = 'image', thumbnail = nil, size = nil, place = 'photo' )
    	image = image_list( @image_date )[id.to_i]
    	image_t = image_list( @image_date )[thumbnail.to_i] if thumbnail
 	end
-	if @cgi.smartphone? then
-		size = ''
-	elsif size
+	if size
 		if size.kind_of?(Array)
 			if size.length > 1
 				size = %Q| width="#{h size[0]}" height="#{h size[1]}"|

--- a/spec/plugin/plugin_helper.rb
+++ b/spec/plugin/plugin_helper.rb
@@ -138,7 +138,7 @@ class PluginFake
 	end
 
 	def smartphone?
-		@conf.cgi.smartphone?
+		false
 	end
   alias iphone? smartphone?
 end
@@ -155,7 +155,7 @@ class CGIFake
 	end
 
 	def smartphone?
-		self.user_agent =~ /iP(?:hone|od)/
+		false
 	end
 end
 


### PR DESCRIPTION
#506 での携帯電話に続き、スマートフォンで特別なページ生成をやめ、ブラウザサイドで対応する。

* metaタグで常にviewportを指定
* Configuration#smartphone? メソッドで常にfalseを返す
* smartphone?によって場合分けしている部分の削除

jsではスクリーンの幅が360未満の場合にスマートフォン扱いするコードにした(amazon.js)