### PR TITLE
use Timeout::Error instead of TimeoutError

### DIFF
--- a/lib/tdiary/filter/spam.rb
+++ b/lib/tdiary/filter/spam.rb
@@ -171,7 +171,7 @@ module TDiary
 					debug("lookup:#{domain}.#{dnsbl} address:#{address}: spam host.")
 					return true
 				end
-			rescue TimeoutError, Resolv::ResolvTimeout
+			rescue Timeout::Error, Resolv::ResolvTimeout
 				debug("lookup:#{domain}.#{dnsbl}: safe host.")
 				return false
 			rescue Resolv::ResolvError, Exception

--- a/misc/plugin/recent_rss.rb
+++ b/misc/plugin/recent_rss.rb
@@ -165,7 +165,7 @@ def recent_rss_fetch_rss(uri, cache_time)
 				raise InvalidResourceError
 			end
 		end
-	rescue TimeoutError, SocketError, StandardError
+	rescue Timeout::Error, SocketError, StandardError
 		raise InvalidResourceError
 	end
 	rss

--- a/misc/plugin/weather.rb
+++ b/misc/plugin/weather.rb
@@ -314,7 +314,7 @@ class Weather
 				d = @conf.to_native( fetch( url, MAXREDIRECT, header ) )
 				parse_html( d, items )
 			end
-		rescue TimeoutError
+		rescue Timeout::Error
 			@error = 'Timeout'
 		rescue
 			@error = @conf.to_native( $!.message.gsub( /[\t\n]/, ' ' ) )

--- a/spec/acceptance/save_conf_dnsbl_spec.rb
+++ b/spec/acceptance/save_conf_dnsbl_spec.rb
@@ -42,7 +42,7 @@ BODY
 	end
 
 	scenario 'IPベースのブラックリストでセーフの場合' do
-		allow(IPSocket).to receive(:getaddress) { raise TimeoutError }
+		allow(IPSocket).to receive(:getaddress) { raise Timeout::Error }
 
 		append_default_diary
 
@@ -92,7 +92,7 @@ BODY
 	end
 
 	scenario 'ドメインベースのブラックリストでセーフの場合' do
-		allow(Resolv).to receive(:getaddress) { raise TimeoutError }
+		allow(Resolv).to receive(:getaddress) { raise Timeout::Error }
 
 		append_default_diary
 


### PR DESCRIPTION
2.3.0 で warning が出るようになった `TimeoutError` がまだ残っていたので `Timeout::Error` に置き換えてしまいました。