### PR TITLE
Replace dependency: gemoji to emot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rack'
 gem 'sprockets'
 gem 'hikidoc'
 gem 'fastimage'
-gem 'gemoji'
+gem 'emot'
 gem 'mail'
 
 group :coffee do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,11 +26,12 @@ GEM
     docile (1.1.5)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
+    emot (0.0.4)
+      thor
     execjs (2.6.0)
     fastimage (1.8.0)
       addressable (~> 2.3, >= 2.3.5)
     ffi (1.9.10)
-    gemoji (2.1.0)
     hikidoc (0.1.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
@@ -127,8 +128,8 @@ DEPENDENCIES
   capybara
   coffee-script
   coveralls (~> 0.7.12)
+  emot
   fastimage
-  gemoji
   hikidoc
   jasmine
   launchy

--- a/lib/tdiary/core_ext.rb
+++ b/lib/tdiary/core_ext.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-require 'gemoji'
+require 'emot'
 
 module TDiary
 	module RequestExtension
@@ -44,8 +44,8 @@ class String
 			emoji_url = %Q[<img src='http://www.emoji-cheat-sheet.com/graphics/emojis/%s.png' width='20' height='20' title='%s' alt='%s' class='emoji' />]
 			if emoji_alias == 'plus1' or emoji_alias == '+1'
 				emoji_url % (['plus1']*3)
-			elsif emoji = Emoji.find_by_alias(emoji_alias)
-				emoji_url % ([CGI.escape(emoji.name)]*3)
+			elsif Emot.unicode(emoji_alias)
+				emoji_url % ([CGI.escape(emoji_alias)]*3)
 			else
 				match
 			end

--- a/spec/core/core_ext_spec.rb
+++ b/spec/core/core_ext_spec.rb
@@ -50,7 +50,7 @@ describe "core extension library" do
 		context "thumbsupでもemojify" do
 			before { @result = "いいね!:thumbsup:".emojify }
 			it do
-				expect(@result).to eq "いいね!<img src='http://www.emoji-cheat-sheet.com/graphics/emojis/%2B1.png' width='20' height='20' title='%2B1' alt='%2B1' class='emoji' />"
+				expect(@result).to eq "いいね!<img src='http://www.emoji-cheat-sheet.com/graphics/emojis/thumbsup.png' width='20' height='20' title='thumbsup' alt='thumbsup' class='emoji' />"
 			end
 		end
 


### PR DESCRIPTION
gemoji の ruby code 部分は MIT/X11 License なのですが，同梱されている画
像が non-free です．tDiary 本体での gemoji の利用は絵文字の画像そのもの
を利用せずに http://www.emoji-cheat-sheet.com/ の URL 参照に変更している
だけかと思います．

画像を同梱しないライブラリへの依存に変更しては如何でしょうか．例えば，と
いうことで https://github.com/melborne/emot を利用する修正を書いてみまし
た．

The "gemoji" has some license issues, e.g.:
  http://words.steveklabnik.com/emoji-licensing
Clearly, this library is not  compatible GPL-2.0+.

This commit replace dependency: gemoji to emot. This library is under
MIT/X11 license and does not contained non-free images.

Signed-off-by: Youhei SASAKI <uwabami@gfd-dennou.org>
