### PR TITLE
tdiaryの依存ライブラリをGemfileではなくgemspecに記述する

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ cache:
 # ignored --deployment option
 bundler_args: "--without server --jobs=3 --retry=3"
 
-before_install:
-  - "echo 'gemspec' > Gemfile.local"
-
 before_script:
   - npm install
   - grunt

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2015-11-26  MATSUOKA Kohei <kohei@machu.jp>
 	* move gems dependency from Gemfile to .gemspec
 	* specify spec.files without git command
+	* remove specs from gem
 
 2015-09-29  SHIBATA Hiroshi  <shibata.hiroshi@gmail.com>
 	* release 4.2.0

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-11-26  MATSUOKA Kohei <kohei@machu.jp>
+	* move gems dependency from Gemfile to .gemspec
+	* specify spec.files without git command
+
+2015-09-29  SHIBATA Hiroshi  <shibata.hiroshi@gmail.com>
+	* release 4.2.0
+
 2015-06-29  MATSUOKA Kohei <kohei@machu.jp>
 	* release 4.1.3
 	* Gemfile: use rack 1.6.4 which sepatates params with ';'. see #485
@@ -55,7 +62,7 @@
 
 2014-12-27  MATSUOKA Kohei <kohei@machu.jp>
 	* lib/tdiary/application.rb: fix #442: call extensions setup before the core setup
-	* lib/tdiary/application/extensions/omniauth.rb: fix error with base_dir 
+	* lib/tdiary/application/extensions/omniauth.rb: fix error with base_dir
 	* lib/tdiary/rack/auth/omniauth.rb: remove github authentication
 
 2014-12-22  SHIBATA Hiroshi  <shibata.hiroshi@gmail.com>
@@ -724,9 +731,9 @@
 	* plugin/00default.rb: fixed bug of no saved referer under new navi_user plugin.
 
 2009-11-24  SHIBATA Hiroshi  <shibata.hiroshi@gmail.com>
-	* tdiary.rb, plugin/00default.rb, 
+	* tdiary.rb, plugin/00default.rb,
 	plugin/{ja,en,zh}/00default.rb: change logger implementation.
-	* tdiary.rb, plugin/00default.rb: change implemention of 
+	* tdiary.rb, plugin/00default.rb: change implemention of
 	navi_user_day to navi_user.rb.
 
 2009-08-26  Kazuhiko  <kazuhiko@fdiary.net>
@@ -878,7 +885,7 @@
 	* **/*.rb: insert magic comment.
 
 2008-11-17 SHIBATA Hiroshi <shibata.hiroshi@gmail.com>
-	* index.rb, update.rb: replaced $defout to $stdout. ($defout is obsolete in ruby1.8) 
+	* index.rb, update.rb: replaced $defout to $stdout. ($defout is obsolete in ruby1.8)
 
 2008-10-31 SHIBATA Hiroshi <shibata.hiroshi@gmail.com>
 	* plugin/00default.rb: escaped comment_form_text. thx fudan.
@@ -955,7 +962,7 @@
 	* skel/footer.rhtml: using rescue on display to RUBY_PATCHLEVEL.
 
 2008-06-23 SHIBATA Hiroshi <shibata.hiroshi@gmail.com>
-	* tdiary.rb: add 'Semulator', 'Vemulator', 'J-EMULATOR' and 'emobile' to 
+	* tdiary.rb: add 'Semulator', 'Vemulator', 'J-EMULATOR' and 'emobile' to
 	mobile user agent.
 	* skel/footer.rhtml: display RUBY_PATCHLEVEL in footer.
 
@@ -1310,7 +1317,7 @@
 
 2006-11-11  Tanaka Akira <akr at fsij.org>
 	* tdiary/wiki_style.rb: support here document ends without CR/LF in plugin.
- 
+
 2006-11-10 TADA Tadashi <sho@spc.gr.jp>
 	* style/wiki_style.rb: fix bug when plugin specified in subtitle.
 
@@ -1320,13 +1327,13 @@
 2006-11-06  Tanaka Akira <akr at fsij.org>
 	* tdiary/hikidoc.rb, tdiary/wiki_style.rb: support here document in wiki
 	style plugin syntax.
- 
-2006-09-13 Shun-ichi TAHARA  <jado at flowernet.gr.jp> 
+
+2006-09-13 Shun-ichi TAHARA  <jado at flowernet.gr.jp>
 	* style/etdiary/etdiary_style.rb: fix bug for mobile mode.
- 
-2006-09-13 Masahiro Sakai  <sakai at tom.sfc.keio.ac.jp> 
+
+2006-09-13 Masahiro Sakai  <sakai at tom.sfc.keio.ac.jp>
 	* style/rd/rd_style.rb: unescapeHTML for parameters of plugins.
- 
+
 2006-09-05 TADA Tadashi <sho@spc.gr.jp>
 	* skel/i.*.rhtml: add navigation link to bottom of pages.
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rack'
-gem 'sprockets'
-gem 'hikidoc'
-gem 'fastimage'
-gem 'gemoji'
-gem 'mail'
+gemspec
 
 group :coffee do
   gem 'coffee-script'
@@ -15,7 +10,6 @@ end
 group :development do
   gem 'pit', require: false
   gem 'racksh', require: false
-  gem 'rake'
   gem 'redcarpet'
 
   group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tdiary (4.2.0)
+    tdiary (4.2.0.20151126)
       bundler (~> 1.3)
       fastimage
       gemoji

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+PATH
+  remote: .
+  specs:
+    tdiary (4.2.0)
+      bundler (~> 1.3)
+      fastimage
+      gemoji
+      hikidoc
+      mail
+      rack
+      rake
+      sprockets
+      thor (~> 0.18)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -24,16 +38,12 @@ GEM
       thor (~> 0.19.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.25)
-      unf (>= 0.0.5, < 1.0.0)
     execjs (2.6.0)
     fastimage (1.8.0)
       addressable (~> 2.3, >= 2.3.5)
     ffi (1.9.10)
     gemoji (2.1.0)
     hikidoc (0.1.0)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
     jasmine (2.3.1)
       jasmine-core (~> 2.3)
       phantomjs
@@ -46,11 +56,11 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.6.2)
+    mime-types (2.99)
     mini_portile (0.6.2)
     multi_json (1.11.2)
     netrc (0.11.0)
-    nokogiri (1.6.6.3)
+    nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
     phantomjs (1.9.8.0)
     pit (0.0.7)
@@ -71,15 +81,14 @@ GEM
     rake (10.4.2)
     redcarpet (3.3.3)
     ref (2.0.0)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
+    rest-client (1.7.3)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.0)
+    rspec-core (3.4.1)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -87,7 +96,7 @@ GEM
     rspec-mocks (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
-    rspec-support (3.4.0)
+    rspec-support (3.4.1)
     rubyzip (1.1.7)
     selenium-webdriver (2.48.1)
       childprocess (~> 0.5)
@@ -113,9 +122,6 @@ GEM
       ref
     thor (0.19.1)
     tins (1.7.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.1)
     websocket (1.2.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -127,24 +133,18 @@ DEPENDENCIES
   capybara
   coffee-script
   coveralls (~> 0.7.12)
-  fastimage
-  gemoji
-  hikidoc
   jasmine
   launchy
-  mail
   pit
   pry-byebug
-  rack
   racksh
-  rake
   redcarpet
   rspec
   selenium-webdriver
   sequel
   simplecov
-  sprockets
   sqlite3
+  tdiary!
   test-unit
   therubyracer
 

--- a/lib/tdiary/cli.rb
+++ b/lib/tdiary/cli.rb
@@ -18,7 +18,7 @@ module TDiary
 			target = File.join(Dir.pwd, name)
 			deploy(target)
 			copy_file('tdiary.conf.beginner', File.join(target, 'tdiary.conf'))
-			template('misc/templates/Gemfile.local.erb', File.join(target, 'Gemfile.local'))
+			template('misc/templates/Gemfile.erb', File.join(target, 'Gemfile'))
 
 			unless options[:'skip-bundle']
 				Bundler.with_clean_env do
@@ -75,7 +75,12 @@ module TDiary
 		def test
 			target = File.join(Dir.pwd, 'tmp/test')
 			deploy(target)
-			append_to_file(File.join(target, 'Gemfile'), "path '#{CLI::source_root}'")
+			copy_file('Gemfile', File.join(target, 'Gemfile'))
+			gsub_file(File.join(target, 'Gemfile'),
+				/^gemspec$/,
+				"gemspec path: '#{CLI::source_root}'"
+			)
+			copy_file('Rakefile', File.join(target, 'Rakefile'))
 			directory('spec', File.join(target, 'spec'))
 			directory('test', File.join(target, 'test'))
 
@@ -171,8 +176,6 @@ module TDiary
 				empty_directory(File.join(target, 'theme'))
 				%w(
 				README.md
-				Gemfile
-				Gemfile.lock
 				config.ru
 				tdiary.conf.beginner
 				tdiary.conf.sample

--- a/lib/tdiary/environment.rb
+++ b/lib/tdiary/environment.rb
@@ -19,3 +19,18 @@ if defined?(Bundler)
   env = env.reject{|e| Bundler.settings.without.include? e }
   Bundler.require *env
 end
+
+# Bundler.require doesn't load gems specified in .gemspec
+# see: https://github.com/bundler/bundler/issues/1041
+#
+# load gems dependented by tdiary
+Bundler.definition.specs.find {|spec|
+  spec.name == 'tdiary'
+}.dependent_specs.each {|spec|
+  begin
+    require spec.name
+  rescue LoadError => e
+    STDERR.puts "failed require '#{spec.name}'"
+    STDERR.puts e
+  end
+}

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = '4.2.0'
+	VERSION = '4.2.0.20151126'
 end

--- a/misc/templates/Gemfile.erb
+++ b/misc/templates/Gemfile.erb
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'tdiary'
+# gem 'tdiary', github: 'tdiary/tdiary-core'
+gem 'tdiary-contrib', github: 'tdiary/tdiary-contrib'
+gem 'tdiary-style-gfm'

--- a/misc/templates/Gemfile.local.erb
+++ b/misc/templates/Gemfile.local.erb
@@ -1,8 +1,0 @@
-gem 'tdiary'
-# use edge tDiary
-# gem 'tdiary', :git => 'git@github.com:tdiary/tdiary-core.git'
-
-# if you use tdiary-contrib gem, uncomment this line.
-# gem 'tdiary-contrib'
-# use edge tDiary contrib
-# gem 'tdiary-contrib', :git => 'git@github.com:tdiary/tdiary-contrib.git'

--- a/tdiary.gemspec
+++ b/tdiary.gemspec
@@ -37,8 +37,18 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 1.9.2'
+  spec.required_ruby_version = '>= 2.0.0'
 
+  # for tdiary command
   spec.add_dependency 'thor', '~> 0.18'
   spec.add_dependency "bundler", "~> 1.3"
+
+  # for tdiary application
+  spec.add_dependency 'rack'
+  spec.add_dependency 'rake'
+  spec.add_dependency 'sprockets'
+  spec.add_dependency 'hikidoc'
+  spec.add_dependency 'fastimage'
+  spec.add_dependency 'gemoji'
+  spec.add_dependency 'mail'
 end

--- a/tdiary.gemspec
+++ b/tdiary.gemspec
@@ -27,14 +27,11 @@ Gem::Specification.new do |spec|
     'lib/**/*',
     'misc/**/*',
     'public/**/*',
-    'spec/**/*',
-    'test/**/*',
     'theme/**/*',
     'vendor/**/*',
     'views/**/*'
   ]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 2.0.0'

--- a/tdiary.gemspec
+++ b/tdiary.gemspec
@@ -13,7 +13,26 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://www.tdiary.org/"
   spec.license       = "GPL2"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = Dir[
+    'ChangeLog',
+    'config.ru',
+    'Gemfile',
+    'Gemfile.lock',
+    'README.md',
+    'Rakefile',
+    'tdiary.conf*',
+    'bin/**/*',
+    'doc/**/*',
+    'js/**/*',
+    'lib/**/*',
+    'misc/**/*',
+    'public/**/*',
+    'spec/**/*',
+    'test/**/*',
+    'theme/**/*',
+    'vendor/**/*',
+    'views/**/*'
+  ]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
PR #515 のコミットを整理しました。

> tdiary/tdiary-contrib#121 と同じようにcore側もgem周りを改善しました。
> 
> * gitがない環境でも.gemspecを読み込めるようにしました
> * tdiary-coreの必須ライブラリはGemfileではなくtdiary.gemspecに記載しました
> 
> tdiary-coreの依存ライブラリを.gemspecに書くようにすれば、gemでインストールしたtdiaryのアップデートが楽になります。今まではgemの更新後にtdiaryインストールディレクトリのGemfileを手動で書き換える必要がありました。