### PR TITLE
fix authentication error by omniauth and rack::session::pool

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2015-12-08  MATSUOKA Kohei <kohei@machu.jp>
+	* fix #494 authentication error by omniauth and rack::session::pool
+
 2015-12-01  MATSUOKA Kohei <kohei@machu.jp>
 	* enable to write TDiary::Application settings in tdiary.conf (@index, @update, @options['base_url'])
 

--- a/lib/tdiary/rack/auth/omniauth.rb
+++ b/lib/tdiary/rack/auth/omniauth.rb
@@ -19,14 +19,15 @@ class TDiary::Rack::Auth::OmniAuth
 			raise NoStrategyFoundError.new("Not found any strategies. Write the omniauth strategy in your Gemfile.local.")
 		end
 
-		@builder = ::Rack::Builder.new(app) {
+		@app = ::Rack::Builder.new(app) {
 			use TDiary::Rack::Session
-		}
-		@builder.instance_eval(&self.class.provider_procs[provider])
+		}.tap {|builder|
+			builder.instance_eval(&self.class.provider_procs[provider])
+		}.to_app
 	end
 
 	def call(env)
-		@builder.call(env)
+		@app.call(env)
 	end
 
 	add_provider(:Twitter) do


### PR DESCRIPTION
#494 で報告のあったTwitterやFacebookの認証を使う場合に、セッション情報を `Rack::Session::Pool` に格納すると認証に失敗する問題を修正しました。

原因は、リクエストのたびに `TDiary::Rack::Session` を作るコードになっていたことです。`Rack::Session::Pool`は自身のオブジェクト内にセッション情報を持つので、リクエストのたびにオブジェクトが作られることでセッション情報が破棄されてしまっていました。