### PR TITLE
Revert "move essential gems from Gemfile to .gemspec"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ cache:
 # ignored --deployment option
 bundler_args: "--without server --jobs=3 --retry=3"
 
+before_install:
+  - "echo 'gemspec' > Gemfile.local"
+
 before_script:
   - npm install
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2015-12-25  MATSUOKA Kohei <kohei@machu.jp>
+	* revert 61b7b6: writing dependency in gemspec, see #527
+
 2015-12-25  TADA Tadashi <t@tdtds.jp>
 	* default.css: more adjust CSS for mobile devices
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,16 @@
 source 'https://rubygems.org'
 
-gemspec
+gem 'rack'
+gem 'sprockets'
+gem 'hikidoc'
+gem 'fastimage'
+gem 'emot'
+gem 'mail'
 
 group :development do
   gem 'pit', require: false
   gem 'racksh', require: false
+  gem 'rake'
   gem 'redcarpet'
 
   group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,7 @@
-PATH
-  remote: .
-  specs:
-    tdiary (4.2.0.20151206)
-      bundler (~> 1.3)
-      emot
-      fastimage
-      hikidoc
-      mail
-      rack
-      rake
-      sprockets
-      thor (~> 0.18)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.8)
+    addressable (2.4.0)
     byebug (8.2.1)
     capybara (2.5.0)
       mime-types (>= 1.16)
@@ -60,7 +46,7 @@ GEM
     mini_portile2 (2.0.0)
     multi_json (1.11.2)
     netrc (0.11.0)
-    nokogiri (1.6.7)
+    nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     phantomjs (1.9.8.0)
     pit (0.0.7)
@@ -110,7 +96,7 @@ GEM
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
     slop (3.6.0)
-    sprockets (3.5.1)
+    sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sqlite3 (1.3.11)
@@ -133,19 +119,22 @@ PLATFORMS
 DEPENDENCIES
   capybara
   coveralls (~> 0.7.12)
+  emot
+  fastimage
+  hikidoc
   jasmine
   launchy
+  mail
   pit
   pry-byebug
+  rack
   racksh
+  rake
   redcarpet
   rspec
   selenium-webdriver
   sequel
   simplecov
+  sprockets
   sqlite3
-  tdiary!
   test-unit
-
-BUNDLED WITH
-   1.10.6

--- a/lib/tdiary/cli.rb
+++ b/lib/tdiary/cli.rb
@@ -18,7 +18,7 @@ module TDiary
 			target = File.join(Dir.pwd, name)
 			deploy(target)
 			copy_file('tdiary.conf.beginner', File.join(target, 'tdiary.conf'))
-			template('misc/templates/Gemfile.erb', File.join(target, 'Gemfile'))
+			template('misc/templates/Gemfile.local.erb', File.join(target, 'Gemfile.local'))
 
 			unless options[:'skip-bundle']
 				Bundler.with_clean_env do
@@ -75,12 +75,7 @@ module TDiary
 		def test
 			target = File.join(Dir.pwd, 'tmp/test')
 			deploy(target)
-			copy_file('Gemfile', File.join(target, 'Gemfile'))
-			gsub_file(File.join(target, 'Gemfile'),
-				/^gemspec$/,
-				"gemspec path: '#{CLI::source_root}'"
-			)
-			copy_file('Rakefile', File.join(target, 'Rakefile'))
+			append_to_file(File.join(target, 'Gemfile'), "path '#{CLI::source_root}'")
 			directory('spec', File.join(target, 'spec'))
 			directory('test', File.join(target, 'test'))
 
@@ -176,6 +171,8 @@ module TDiary
 				empty_directory(File.join(target, 'theme'))
 				%w(
 				README.md
+				Gemfile
+				Gemfile.lock
 				config.ru
 				tdiary.conf.beginner
 				tdiary.conf.sample

--- a/lib/tdiary/environment.rb
+++ b/lib/tdiary/environment.rb
@@ -19,18 +19,3 @@ if defined?(Bundler)
   env = env.reject{|e| Bundler.settings.without.include? e }
   Bundler.require *env
 end
-
-# Bundler.require doesn't load gems specified in .gemspec
-# see: https://github.com/bundler/bundler/issues/1041
-#
-# load gems dependented by tdiary
-Bundler.definition.specs.find {|spec|
-  spec.name == 'tdiary'
-}.dependent_specs.each {|spec|
-  begin
-    require spec.name
-  rescue LoadError => e
-    STDERR.puts "failed require '#{spec.name}'"
-    STDERR.puts e
-  end
-}

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = '4.2.0.20151206'
+	VERSION = '4.2.0.20151225'
 end

--- a/misc/templates/Gemfile.erb
+++ b/misc/templates/Gemfile.erb
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'tdiary'
-# gem 'tdiary', github: 'tdiary/tdiary-core'
-gem 'tdiary-contrib', github: 'tdiary/tdiary-contrib'
-gem 'tdiary-style-gfm'

--- a/tdiary.gemspec
+++ b/tdiary.gemspec
@@ -36,16 +36,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  # for tdiary command
   spec.add_dependency 'thor', '~> 0.18'
   spec.add_dependency "bundler", "~> 1.3"
-
-  # for tdiary application
-  spec.add_dependency 'rack'
-  spec.add_dependency 'rake'
-  spec.add_dependency 'sprockets'
-  spec.add_dependency 'hikidoc'
-  spec.add_dependency 'fastimage'
-  spec.add_dependency 'emot'
-  spec.add_dependency 'mail'
 end


### PR DESCRIPTION
Herokuでbuildできない問題 (#527) を解決するために、 61b7b6c520e69a09d717b089fbfb8f012e2b7ed8 のコミットをrevertしました。