### PR TITLE
fix error when @index or @update specified with URL in tdiary.conf

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2015-12-31  TADA Tadashi <t@tdtds.jp>
+	* application.rb: fix error when @index or @update specified with URL in tdiary.conf
+
 2015-12-29  MATSUOKA Kohei <kohei@machu.jp>
 	* release 4.2.1
 

--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -76,11 +76,11 @@ module TDiary
 		end
 
 		def index_path
-			(Pathname.new('/') + TDiary.configuration.index).to_s
+			(Pathname.new('/') + URI(TDiary.configuration.index).path).to_s
 		end
 
 		def update_path
-			(Pathname.new('/') + TDiary.configuration.update).to_s
+			(Pathname.new('/') + URI(TDiary.configuration.update).path).to_s
 		end
 
 		def assets_path


### PR DESCRIPTION
tdiary.confで@indexや@updateがURLだった場合にrouteが見つからずにエラーになるので修正。
@machu どうですか?