### PR TITLE
support forwarded HTTPS

### DIFF
--- a/lib/tdiary/core_ext.rb
+++ b/lib/tdiary/core_ext.rb
@@ -65,6 +65,7 @@ class CGI
 	end
 
 	def https?
+		return true if env_table['HTTP_X_FORWARDED_PROTO'] == 'https'
 		return false if env_table['HTTPS'].nil? or /off/i =~ env_table['HTTPS'] or env_table['HTTPS'] == ''
 		true
 	end


### PR DESCRIPTION
日記のURLはhttpsだけど、reverse proxyからtDiaryまではhttpで来てるような環境(Herokuとか)にはENV['HTTPS']が入っていないので、ENV['HTTP_X_FORWARDED_PROTO']も見るようにした。