### PR TITLE
support category-lite plugin in title_tag plugin

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2016-01-08  TADA Tadashi <t@tdtds.jp>
+	* title_tag.rb: support category-lite plugin
+
 2016-01-05  TADA Tadashi <t@tdtds.jp>
 	* system_update.rb, README.md: enable deploy master branch to heroku
 

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = '4.2.1.20160105'
+	VERSION = '4.2.1.20160108'
 end

--- a/misc/plugin/title_tag.rb
+++ b/misc/plugin/title_tag.rb
@@ -57,7 +57,7 @@ def title_tag
 			day_title << apply_plugin(diary.title, true) << ':'
 		end
 		t2 = ''
-		if @plugin_files.grep(/\/category.rb$/).empty? then
+		if @plugin_files.grep(/\/category.*\.rb$/).empty? then
 			t2 << diary.all_subtitles_to_html.join(', ')
 		else
 			t2 << diary.all_stripped_subtitles_to_html.join(', ')


### PR DESCRIPTION
title_tagプラグインの中でcategoryプラグインの存在確認をしている箇所があったので、category-lite(を含むカテゴリプラグイン仲間)を検出するように条件を緩和。