### PR TITLE
expand load path in config.ru of Heroku

### DIFF
--- a/misc/paas/heroku/config.ru
+++ b/misc/paas/heroku/config.ru
@@ -1,4 +1,4 @@
-$:.unshift( File.join(File::dirname( __FILE__ ), 'lib' ).untaint )
+$:.unshift( File.join(File::expand_path(File::dirname( __FILE__ )), 'lib' ).untaint )
 require 'tdiary/application'
 
 use ::Rack::Reloader unless ENV['RACK_ENV'] == 'production'


### PR DESCRIPTION
Heroku用のconfig.ruで`$LOAD_PATH`に追加する`./lib`のフルパス化が漏れていたので反映。

これ、ベースのconfig.ruとは`base_dir`を指定してるかどうかしか違いがないんだけど、共通化するわけにはいかないんでしたっけ? > @machu 