### PR TITLE
delete config.ru for Heroku (use default one)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2016-01-19  TADA Tadashi <t@tdtds.jp>
+	* delete config.ru for Heroku (use default one)
+
 2016-01-08  TADA Tadashi <t@tdtds.jp>
 	* title_tag.rb: support category-lite plugin
 

--- a/misc/paas/heroku/config.ru
+++ b/misc/paas/heroku/config.ru
@@ -1,6 +1,0 @@
-$:.unshift( File.join(File::dirname( __FILE__ ), 'lib' ).untaint )
-require 'tdiary/application'
-
-use ::Rack::Reloader unless ENV['RACK_ENV'] == 'production'
-base_dir = '/'
-run TDiary::Application.new( base_dir )


### PR DESCRIPTION
Heroku用の不要なconfig.ruを削除してデフォルトのものを使うように変更