### PR TITLE
fix the assets_copy command in cli

### DIFF
--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -68,13 +68,13 @@ module TDiary
 			end
 		end
 
-	protected
 		def assets_paths
 			TDiary::Extensions::constants.map {|extension|
 				TDiary::Extensions::const_get( extension ).assets_path
 			}.flatten.uniq
 		end
 
+	protected
 		def index_path
 			(Pathname.new('/') + URI(TDiary.configuration.index).path).to_s
 		end

--- a/lib/tdiary/cli.rb
+++ b/lib/tdiary/cli.rb
@@ -60,7 +60,7 @@ module TDiary
 		def assets_copy
 			require 'tdiary'
 			assets_path = File.join(TDiary.server_root, 'public/assets')
-			TDiary::Application.config.assets_paths.each do |path|
+			TDiary::Application.new.assets_paths.each do |path|
 				Dir.glob(File.join(path, '*')).each do |entity|
 					if File.directory?(entity)
 						directory entity, File.join(assets_path, File.basename(entity))


### PR DESCRIPTION
gem の tdiary assets_copy コマンドが

```
(略)/tdiary-4.2.1.20160108/lib/tdiary/cli.rb:63:in `assets_copy': undefined method `config' for TDiary::Application:Class (NoMethodError)
```

というエラーで動かなかったので修正しました。
修正方法がこれで正しいか自信がないので、ご教示いただければ幸いです。
