### PR TITLE
Fix image plugin for jQuery 2.x

### DIFF
--- a/js/image.js
+++ b/js/image.js
@@ -12,12 +12,12 @@ function insertImage(text){
 
 $(function(){
 	$('.image-img')
-	.live('hover', function(){
+	.on('hover', function(){
 		$(this).css('cursor', 'pointer');
 	}, function(){
 		$(this).css('cursor', 'default');
 	})
-	.live('click', function(){
+	.on('click', function(){
 		var idx = this.id.replace('image-index-', '');
 		var w = $('#image-info-' + idx + ' .image-width').text();
 		var h = $('#image-info-' + idx + ' .image-height').text();
@@ -107,7 +107,7 @@ $(function(){
 	};
 
 	$('#plugin-image-delimage')
-	.live('submit', function(e){
+	.on('submit', function(e){
 		e.preventDefault();
 		
 		var ids = $.map($('#image-table input[name="plugin_image_id"]:checked'), function(i){


### PR DESCRIPTION
imageプラグインの image.js の中で、廃止された`` .live`` 関数が使用されており、これがエラーになっていて後続の JavaScript が実行されずにおりましたので、``.on`` に変更しました。
(編集画面 picasa.js が動いていなかったので気付きました。picasa.js は修正不要でした :sweat_smile:)
この修正でよろしいでしょうか。ご覧ください。