### PR TITLE
print only diary name when diary has no subtitles

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2016-01-26  TADA Tadashi <t@tdtds.jp>
+	* title_tag.rb: print only diary name when diary has no subtitles
+
 2016-01-19  TADA Tadashi <t@tdtds.jp>
 	* delete config.ru for Heroku (use default one)
 

--- a/misc/plugin/title_tag.rb
+++ b/misc/plugin/title_tag.rb
@@ -58,11 +58,16 @@ def title_tag
 		end
 		t2 = ''
 		if @plugin_files.grep(/\/category.*\.rb$/).empty? then
-			t2 << diary.all_subtitles_to_html.join(', ')
+			t2 << diary.all_subtitles_to_html.delete_if{|s|s.size == 0}.join(', ')
 		else
-			t2 << diary.all_stripped_subtitles_to_html.join(', ')
+			t2 << diary.all_stripped_subtitles_to_html.delete_if{|s|s.size == 0}.join(', ')
 		end
-		return "<title>#{h day_title} #{@conf.shorten(apply_plugin(t2, true))} - #{h( site_title )}</title>"
+		sub_part = "#{h day_title} #{@conf.shorten(apply_plugin(t2, true))}"
+		if sub_part.size <= 1
+			return "<title>#{h( site_title )}</title>"
+		else
+			return "<title>#{sub_part} - #{h( site_title )}</title>"
+		end
 	elsif @mode == 'categoryview' then
 		return @conf.shorten("<title>#{h( @html_title )}#{h( category_title() )}</title>")
 	else


### PR DESCRIPTION
title_tagプラグインで、日タイトルやサブタイトルがない場合には日記名のみを<title>要素に設定するように修正