### PR TITLE
change order loading CSS and JS

### DIFF
--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -213,9 +213,9 @@ add_header_proc do
 	#{icon_tag}
 	#{default_ogp}
 	#{description_tag}
+	#{css_tag.chomp}
 	#{jquery_tag.chomp}
 	#{script_tag.chomp}
-	#{css_tag.chomp}
 	#{title_tag.chomp}
 	#{robot_control.chomp}
 	HEADER


### PR DESCRIPTION
CSSのロードを(プラグインを入れていればたくさんになる) JavaScript ファイルの前にする PR です。

- iOS 9.2.1 で、大量のjsの後にCSSを読むようにしていると異様にCSSロードが遅い
- そもそも[CSSを先に読み込んだ方がブラウザにとってパフォーマンスがよいらしい](http://stackoverflow.com/questions/4198624/order-of-loading-external-css-and-javascript-files)

という理由から、CSSのロードを先にした次第です。
もし問題がなければ採用していただければ天にも昇るロード心地が致します。