### PR TITLE
replace category plugin by contrib/category-lite plugin. fix #528

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 services: memcache
 
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2016-03-09  TADA Tadashi <t@tdtds.jp>
+	* replace category.rb plugin by contrib/category-lite.rb plugin
+
 2016-01-26  TADA Tadashi <t@tdtds.jp>
 	* title_tag.rb: print only diary name when diary has no subtitles
 

--- a/misc/plugin/category.rb
+++ b/misc/plugin/category.rb
@@ -1,736 +1,229 @@
-# category.rb
 #
-# Copyright (c) 2003 Junichiro KITA <kita@kitaj.no-ip.com>
+# category.rb : tDiary plugin for show category pages
+#
+# Copyright (C) 2016 TADA Tadashi
 # Distributed under the GPL2 or any later version.
 #
 
-#
-# initialize
-#
-def category_init
-	@conf['category.header1'] ||= %Q[<div class="adminmenu">\n<p>\n<%= category_navi %>\n</p>\n</div>\n]
-	@conf['category.header2'] ||= %Q[<p>Categories |\n<%= category_list %>\n</p>\n]
-	@conf['category.edit_support'] = @conf['category.edit_support'].to_i rescue 1
-end
-category_init
 
-def category_icon_location_init
-	@category_icon_dir = (@conf['category.icon_dir'] || './icons/').sub(%r|/*$|, '/')
-	@category_icon_url = (@conf['category.icon_url'] || './icons/').sub(%r|/*$|, '/')
-end
+# read cache here so that you can use category with secure mode.
+@conf['category.header1'] = ''
+@conf['category.header2'] = '<%= category_dropdown_list %>'
+@category_icon = {}
+@categories = transaction('category'){|db|db.keys}.sort_by{|c|c.downcase}
 
-def category_icon_init
-	category_icon_location_init
-	@conf['category.icon'] ||= ''
+module Category
+	class Info
+		def initialize(cgi, _, conf)
+			@cgi, @conf = cgi, conf
+		end
 
-	@category_icon = {}
-	@conf['category.icon'].split(/\n/).each do |l|
-		c, i = l.split
-		next if c.nil? or i.nil?
-		@category_icon[c] = i if File.exist?("#{@category_icon_dir}#{i}".untaint)
+		def category
+			@name || (@name = @conf.to_native(@cgi.params['category'][0], @conf.encoding_old))
+		end
 	end
 end
-category_icon_init
 
-#
-# plugin methods
-#
-def category_form
-	# don't you need this method any more?
+def category_title
+	info = Category::Info.new(@cgi, nil, @conf)
+	"[#{info.category}]"
 end
 
 def category_anchor(category)
-	period = @conf['category.period'] || 'quarter'
-	period_string =
-		case period
-		when "month"
-			"year=#{@date.year};month=#{'%02d' % @date.month};"
-		when "quarter"
-			"year=#{@date.year};month=#{(@date.month - 1) / 3 + 1}Q;"
-		when "half"
-			"year=#{@date.year};month=#{(@date.month - 1) / 6 + 1}H;"
-		when "year"
-			"year=#{@date.year};"
-		else
-			""
+	%Q|[<a href="#{h @index}?category=#{u category}" title="#{h category}">#{h category}</a>]|
+end
+
+def category_dropdown_list(label = nil, _ = nil)
+	label ||= 'show category list'
+
+	info = Category::Info.new(@cgi, _, @conf)
+	category = info.category
+	category = [] if category.empty?
+
+	options = ''
+	@categories.each do |c|
+		options << %Q|<option value="#{h c}"#{" selected" if category.include?(c)}>#{h c}</option>\n|
+	end
+
+	<<-HTML
+		<form method="get" action="#{h @index}"><div>
+			<select name="category">
+		#{options}
+			</select>
+			<input type="submit" value="#{label}">
+		</div></form>
+	HTML
+end
+
+def category_transaction(categories)
+	transaction('category') do |db|
+		(categories || db.keys).each do |category|
+			Hash[*JSON.load(db.get(category) || '{}').sort_by{|d,_|d}.flatten(1)].each do |ymd, diaries|
+				yield db, category, ymd, diaries
+			end
 		end
-	if @category_icon[category]
-		%Q|<a href="#{h @index}?#{period_string}category=#{u category}" title="#{h category}"><img class="category" src="#{h @category_icon_url}#{h @category_icon[category]}" alt="#{h category}"></a>|
-	else
-		%Q|[<a href="#{h @index}?#{period_string}category=#{u category}" title="#{h category}">#{h category}</a>]|
 	end
-end
-
-def category_navi_anchor(info, label)
-	((!label.nil?) && label.empty?) ? '' : %Q[<span class="adminmenu">#{info.make_anchor(label)}</span>\n]
-end
-
-def category_navi
-	info = Category::Info.new(@cgi, @years, @conf)
-	mode = info.mode
-
-	result = ''
-	case mode
-	when :year, :half, :quarter, :month
-		all_diary = Category::Info.new(@cgi, @years, @conf, year: -1, month: -1)
-		all = Category::Info.new(@cgi, @years, @conf, category: ['ALL'], year: -1, month: -1)
-		result << category_navi_anchor(info.prev, @conf['category.prev_' + mode.to_s])
-		result << category_navi_anchor(info.next, @conf['category.next_' + mode.to_s])
-		result << category_navi_anchor(all_diary, @conf['category.all_diary'])
-		result << category_navi_anchor(all, @conf['category.all'])
-	when :all
-		year = Category::Info.new(@cgi, @years, @conf, year: Time.now.year.to_s)
-		half = Category::Info.new(@cgi, @years, @conf, year: Time.now.year.to_s, month: "#{((Time.now.month - 1) / 6 + 1)}H")
-		quarter = Category::Info.new(@cgi, @years, @conf, year: Time.now.year.to_s, month: "#{((Time.now.month - 1) / 3 + 1)}Q")
-		month = Category::Info.new(@cgi, @years, @conf, year: Time.now.year.to_s, month: '%02d' % Time.now.month)
-		result << category_navi_anchor(year, @conf['category.this_year'])
-		result << category_navi_anchor(half, @conf['category.this_half'])
-		result << category_navi_anchor(quarter, @conf['category.this_quarter'])
-		result << category_navi_anchor(month, @conf['category.this_month'])
-	end
-	if !info.category.include?('ALL') then
-		all_category = Category::Info.new(@cgi, @years, @conf, category: ['ALL'])
-		result << category_navi_anchor(all_category, @conf['category.all_category'])
-	end
-	result
 end
 
 def category_list_sections
-	info = Category::Info.new(@cgi, @years, @conf)
+	info = Category::Info.new(@cgi, nil, @conf)
+
 	r = ''
-
-	raise ::TDiary::NotFound if @categorized.empty? and bot?
-
-	@categorized.to_a.sort_by{|e| e[0].downcase}.each do |c, v|
-		info.category = [c]
-		if @category_icon[c]
-			img = %Q|<img class="category" src="#{h @category_icon_url}#{h @category_icon[c]}" alt="#{h c}">|
-		else
-			img = ''
+	r << <<-HTML
+		<div class="category day">
+			<h2>
+				<span class="title">
+					<a href="#{h @conf.index}?category=#{u info.category}">#{h info.category}</a>
+				</span>
+			</h2>
+			<div class="body">
+				<ul class="category">
+	HTML
+	category_transaction([info.category]) do |db, category, ymd, diaries|
+		date = Time.local(*ymd.scan(/(.{4})(..)(..)/)[0]).strftime(@conf.date_format)
+		diaries.sort_by{|i|i[0]}.each do |idx, title, excerpt|
+			r << <<-HTML
+				<li>
+					<a href="#{h @index}#{anchor "#{ymd}#p#{'%02d' % idx}"}" title="#{h excerpt}">
+						#{date}#p#{'%02d' % idx}
+					</a>
+					#{apply_plugin(title)}
+				</li>
+			HTML
 		end
-		r << <<HTML
-<div class="category day">
-	<h2><span class="title">#{img}#{info.make_anchor}</span></h2>
-	<div class="body">
-		<ul class="category">
-HTML
-		v.to_a.sort_by{|e| e[0]}.each do |ymd, ary|
-			text = Time.local(ymd[0,4], ymd[4,2], ymd[6,2]).strftime(@conf.date_format)
-			ary.sort.each do |idx, title, excerpt|
-				r << %Q|\t\t\t<li><a href="#{h @index}#{anchor "#{ymd}#p#{'%02d' % idx}"}" title="#{h excerpt}">#{text}#p#{'%02d' % idx}</a> #{apply_plugin(title)}</li>\n|
-			end
-		end
-		r << <<HTML
-		</ul>
-	</div>
-</div>
-HTML
 	end
-	r
+	r << <<-HTML
+				</ul>
+			</div>
+		</div>
+	HTML
+	return r
 end
 
-def category_list_sections_mobile
-	info = Category::Info.new(@cgi, @years, @conf)
-	r = ''
+def category_serialize(diary)
+	data = {}
+	ymd = diary.date.strftime('%Y%m%d')
 
-	raise ::TDiary::NotFound if @categorized.empty? and bot?
-
-	@categorized.to_a.sort_by{|e| e[0].downcase}.each do |c, v|
-		info.category = [c]
-		r << "<H2>#{info.make_anchor}</H2>"
-		r << "<UL>"
-		v.to_a.sort_by{|e| e[0]}.each do |ymd, ary|
-			text = Time.local(ymd[0,4], ymd[4,2], ymd[6,2]).strftime(@conf.date_format)
-			ary.sort.each do |idx, title, excerpt|
-				r << %Q|<LI><A HREF="#{h @index}#{anchor "#{ymd}#p#{'%02d' % idx}"}">#{text}#p#{'%02d' % idx}</A> #{apply_plugin(title)}</LI>\n|
+	idx = 1
+	diary.each_section do |s|
+		s.categories.each do |c|
+			data[c] ||= {}
+			data[c][ymd] ||= []
+			body = <<-EVAL.gsub(/^\t+/, '')
+				text = apply_plugin(<<'BODY', true)
+				#{s.body_to_html}
+				BODY
+			EVAL
+			shorten = begin
+				@conf.shorten(eval(body.untaint))
+			rescue NameError
+				""
 			end
+			data[c][ymd] << [idx, s.stripped_subtitle_to_html, shorten]
 		end
-		r << "</UL>"
+		idx +=1
 	end
-	r
+	data
 end
 
-def category_list
-	info = Category::Info.new(@cgi, @years, @conf)
-	@categories.map do |c|
-		info.category = [c]
-		info.make_anchor
-	end.join(" | \n")
-end
-
-def category_dropdown_list(label = nil, multiple = nil)
-	label ||= 'Categorize!'
-	multiple ||= false
-
-	info = Category::Info.new(@cgi, @years, @conf)
-	category = info.category
-	if category.empty?
-		category = ['ALL']
-	end
-
-	options = ''
-	(['ALL'] + @categories).each do |c|
-		options << %Q|\t\t<option value="#{h c}"#{" selected" if category.include?(c)}>#{h c}</option>\n|
-	end
-
-	params = ''
-	params << %Q[<input type="hidden" name="year" value="#{h info.year}">] if info.year
-	params << %Q[<input type="hidden" name="month" value="#{h info.month}">] if info.month
-
-	<<HTML
-<form method="get" action="#{h @index}"><div>
-	<select name="category"#{" multiple" if multiple}>
-#{options}
-	</select>
-	#{params}
-	<input type="submit" value="#{label}">
-</div></form>
-HTML
-end
-
-
-#
-# misc
-#
-
-def category_icon_save
-	@conf['category.icon'] = @category_icon.map {|c, i| "#{c} #{i}"}.join("\n")
-end
-
-
-module Category
-
-#
-# Info
-#
-class Info
-	include ERB::Util
-
-	def initialize(cgi, years, conf, args = {})
-		@cgi = cgi
-		@years = years
-		@conf = conf
-		@category = args[:category] || @cgi.params['category'].map do |c|
-			@conf.to_native(c, @conf.encoding_old)
-		end
-		@year = args[:year] || @cgi.params['year'][0]
-		@month = args[:month] || @cgi.params['month'][0]
-		@mode = :all
-		set_mode
-	end
-
-protected
-	attr_writer :year
-	attr_writer :month
-public
-	attr :category, true
-	attr_reader :year
-	attr_reader :month
-	attr_reader :mode
-
-	def prev
-		pp = self.dup
-
-		case mode
-		when :half
-			h = @month.to_i
-			if h == 1
-				pp.month = "2H"
-				pp.year = (@year.to_i - 1).to_s if @year
-			else
-				pp.month = "1H"
+def category_rebuild(years)
+	transaction('category') do |db|
+		cache = Hash.new{{}}
+		@years.each do |y, ms|
+			ms.each do |m|
+				m = DiaryContainer::find_by_month(@conf, "#{y}#{m}")
+				m.diaries.each do |ymd, diary|
+					next if !diary.visible? or !diary.categorizable?
+					serialize = category_serialize(diary)
+					serialize.keys.each do |category|
+						cache[category] = cache[category].merge!(serialize[category])
+					end
+				end
 			end
-		when :quarter
-			q = @month.to_i
-			if q == 1
-				pp.month = "4Q"
-				pp.year = (@year.to_i - 1).to_s if @year
-			else
-				pp.month = "#{q - 1}Q"
-			end
-		when :month
-			m = @month.to_i
-			if m == 1
-				pp.month = "12"
-				pp.year = (@year.to_i - 1).to_s if @year
-			else
-				pp.month = '%02d' % (m - 1)
-			end
-		when :year
-			pp.year = (@year.to_i - 1).to_s
 		end
-		pp
-	end
-
-	def next
-		pp = self.dup
-
-		case mode
-		when :half
-			h = @month.to_i
-			if h == 2
-				pp.month = "1H"
-				pp.year = (@year.to_i + 1).to_s if @year
-			else
-				pp.month = "2H"
-			end
-		when :quarter
-			q = @month.to_i
-			if q == 4
-				pp.month = "1Q"
-				pp.year = (@year.to_i + 1).to_s if @year
-			else
-				pp.month = "#{q + 1}Q"
-			end
-		when :month
-			m = @month.to_i
-			if m == 12
-				pp.month = "01"
-				pp.year = (@year.to_i + 1).to_s if @year
-			else
-				pp.month = '%02d' % (m + 1)
-			end
-		when :year
-			pp.year = (@year.to_i + 1).to_s
+		db.keys.each {|key| db.delete(key)}
+		cache.each do |category, diaries|
+			db.set(category, diaries.to_json)
 		end
-		pp
-	end
-
-	def make_anchor(label = nil)
-		a = @category.map {|c| "category=#{u c}"}.join(';')
-		a << ";year=#{@year}" if @year
-		a << ";month=#{@month}" if @month
-		if label
-			case mode
-			when :year
-				label = label.gsub(/\$1/, @year)
-			when :month, :quarter, :half
-				label = label.gsub(/\$2/, @month)
-				label = label.gsub(/\$1/, @year || '*')
-			end
-		else
-			label = @category.to_a.join(':')
-		end
-		%Q|<a href="#{h @conf.index}?#{h a}">#{h label}</a>|
-	end
-
-	#
-	# return ym_spec
-	#
-	# {"yyyy" => ["mm", ...], ...}
-	#
-	# date spec:
-	#  (1) none               -> all diary
-	#  (2) month=xH           -> all diary in xH of all year
-	#  (3) year=YYYY;month=xH -> all diary in YYYY/xH
-	#  (4) month=xQ           -> all diary in xQ of all year
-	#  (5) year=YYYY;month=xQ -> all diary in YYYY/xQ
-	#  (6) month=MM           -> all diary in MM of all year
-	#  (7) year=YYYY;month=MM -> all diary in YYYY/MM
-	#  (8) year=YYYY          -> all diary in YYYY
-	#
-	def years
-		if @mode == :all
-			return @years
-		end
-
-		months = case @mode
-		when :half
-			[('01'..'06'), ('07'..'12')][@month.to_i - 1].to_a
-		when :quarter
-			[['01', '02', '03'], ['04', '05', '06'], ['07', '08', '09'], ['10', '11', '12']][@month.to_i - 1]
-		when :month
-			[@month]
-		else
-			('01'..'12').to_a
-		end
-
-		r = {}
-		(@year ? [@year] : @years.keys).each do |y|
-			r[y] = months
-		end
-		r
-	end
-
-	#
-	# date spec:
-	#  (1) none                -> all
-	#  (2) month=xH            -> half
-	#  (3) year=YYYY;month=xH  -> half
-	#  (4) month=xQ            -> quarter
-	#  (5) year=YYYY;month=xQ  -> quarter
-	#  (6) month=MM            -> month
-	#  (7) year=YYYY;month=MM  -> month
-	#  (8) year=YYYY           -> year
-	#
-	def set_mode
-		if @year.nil? and @month.nil?
-			@mode = :all
-		end
-
-		if /\d{4}/ === @year.to_s
-			@mode = :year
-		else
-			@year = nil
-		end
-
-		if /[12]H/ === @month.to_s
-			@mode = :half
-		elsif /[1-4]Q/ === @month.to_s
-			@mode = :quarter
-		elsif (1..12).include?(@month.to_i)
-			@mode = :month
-		else
-			@month = nil
-		end
-
 	end
 end
 
-#
-# Cache
-#
-class Cache
-	include ERB::Util
+add_update_proc do
+	if /^(append|replace)$/ =~ @mode
+		ymd = @date.strftime('%Y%m%d')
+		diary = @diaries[ymd]
+		serialize = category_serialize(diary)
 
-	def initialize(conf, bind)
-		@conf = conf
-		@binding = bind                           # ...... very ugly
-		@plugin = @binding.eval('self')
-		@categories = nil
-	end
-
-	def get(db, cat)
-		JSON.load(db.get(cat) || '{}')
-	end
-
-	def set(db, cat, data)
-		db.set(cat, data.to_json)
-	end
-
-	def add_categories(list)
-		return if list.nil? or list.empty?
-		replace_categories(restore_categories + list)
-	end
-
-	def replace_categories(list)
-		@categories = list
-	end
-
-	def restore_categories
-		return @categories if @categories
-		@plugin.__send__(:transaction, 'category') do |db|
-			@categories = db.keys
-		end
-		return @categories
-	end
-
-	#
-	# cache each section of diary
-	# used in update_proc
-	#
-	def replace_sections(diary)
-		return if diary.nil? or !diary.categorizable?
-
-		categorized = categorize_diary(diary)
-		categories = restore_categories
-		deleted = []
-		ymd = diary.date.strftime('%Y%m%d')
-
-		@plugin.__send__(:transaction, 'category') do |db|
-			categories.each do |c|
-				cat = get(db, c) || {}
-				if diary.visible? and categorized[c]
-					cat.update(categorized[c])
-					set(db, c, cat)
+		transaction('category') do |db|
+			(db.keys + serialize.keys).uniq.each do |category|
+				data = JSON.load(db.get(category) || '{}')
+				if diary.visible? and serialize[category]
+					data.update(serialize[category])
+					db.set(category, data.to_json)
 				else
-					# diary is invisible or sections of this category is deleted
-					cat.delete(ymd)
-					if cat.empty?
-						db.delete(c)
-						deleted << c
+					data.delete(ymd)
+					if data.empty?
+						db.delete(category)
 					else
-						set(db, c, cat)
-					end
-				end
-			end
-
-			if !deleted.empty?
-				replace_categories(categories - deleted)
-			end
-		end
-	end
-
-	#
-	# (re)create category cache
-	#
-	def recreate(years)
-		list = []
-		@plugin.__send__(:transaction, 'category') do |db|
-			db.keys.each {|key|db.delete(key)}
-
-			years.each do |y, ms|
-				ms.each do |m|
-					m = DiaryContainer::find_by_month(@conf, "#{y}#{m}")
-					m.diaries.each do |ymd, diary|
-						next if !diary.visible? or !diary.categorizable?
-						categorized = categorize_diary(diary)
-						categorized.keys.each do |c|
-							cat = get(db, c) || {}
-							set(db, c, cat.update(categorized[c]))
-						end
-						diary.each_section do |s|
-							list |= s.categories unless s.categories.empty?
-						end
+						db.set(category, data.to_json)
 					end
 				end
 			end
 		end
-
-		replace_categories(list)
-	end
-
-	#
-	# categorize sections of category of years
-	#
-	# {"category" => {"yyyymmdd" => [[idx, title, excerpt], ...], ...}, ...}
-	#
-	def categorize(category, years)
-		categories = category - ['ALL']
-		if categories.empty?
-			categories = restore_categories
-		else
-			categories &= restore_categories
-		end
-
-		categorized = {}
-		begin
-			categorized.clear
-			categories.each do |c|
-				@plugin.__send__(:transaction, 'category') do |db|
-					categorized[c] = get(db, c)
-				end
-				categorized[c].keys.each do |ymd|
-					y, m = ymd[0,4], ymd[4,2]
-					if years[y].nil? or !years[y].include?(m)
-						categorized[c].delete(ymd)
-					end
-				end
-				categorized.delete(c) if categorized[c].empty?
-			end
-		rescue NoMethodError	# when categorized[c] is nil
-			recreate(years)
-			retry
-		end
-
-		categorized
-	end
-
-private
-	def cache_file(category = nil)
-		if category
-			"#{@dir}/#{u( category ).gsub(/%20/,'+')}".untaint
-		else
-			"#{@dir}/category_list"
-		end
-	end
-
-	#
-	# categorize sections of diary
-	#
-	# {"category" => {"yyyymmdd" => [[idx, title, excerpt], ...]}}
-	#
-	def categorize_diary(diary)
-		categorized = {}
-		ymd = diary.date.strftime('%Y%m%d')
-
-		idx = 1
-		diary.each_section do |s|
-			s.categories.each do |c|
-				categorized[c] = {} if categorized[c].nil?
-				categorized[c][ymd] = [] if categorized[c][ymd].nil?
-				body = <<EVAL
-text = apply_plugin(<<'BODY', true)
-#{s.body_to_html}
-BODY
-EVAL
-				shorten = begin
-					@conf.shorten(eval(body.untaint, @binding))
-				rescue NameError
-					""
-				end
-				categorized[c][ymd] << [idx, s.stripped_subtitle_to_html, shorten]
-			end
-			idx +=1
-		end
-
-		categorized
 	end
 end
 
-end # module Category
-
-# read cache here so that you can use category with secure mode.
-@category_cache = Category::Cache.new(@conf, binding)
-
 #
-# display categories on update form
+# edit support: insert category to editing diary using JavaScript
 #
-def category_edit_support_flatlist
+def category_edit_support_flatlist(categories)
 	ret = ''
 	ret << '<div class="field title">'
 	ret << "#{@category_conf_label}:\n"
-	@categories.each do |c|
+	categories.each do |c|
 		ret << %Q!| <span class="category-item">#{h c}</span>\n!
 	end
 	ret << "|\n</div>\n<br>\n"
 	ret
 end
 
-def category_edit_support_dropdown
+def category_edit_support_dropdown(categories)
 	ret = ''
 	ret << '<div class="field title">'
 	ret << %Q|#{@category_conf_label}: <select id="category-candidate" name="category-candidate">\n|
-	@categories.each do |c|
+	categories.each do |c|
 		ret << %Q!<option>#{h c}</option>\n!
 	end
 	ret << "|\n</select>\n</div>\n<br>\n"
 	ret
 end
 
-if @conf['category.edit_support'] != 0 then
+if @mode =~ /^(form|edit)$/ and @conf['category.edit_support'] != 0
 	enable_js( 'category.js' )
 	add_edit_proc do |date|
 		ret = ''
-		unless @categories.size == 0 then
-			ret << if @conf['category.edit_support'] == 2 then
-				category_edit_support_dropdown
-			else
-				category_edit_support_flatlist
+		transaction('category') do |db|
+			categories = db.keys
+			unless categories.size == 0 then
+				if @conf['category.edit_support'] == 2 then
+					ret << category_edit_support_dropdown(categories)
+				else
+					ret << category_edit_support_flatlist(categories)
+				end
 			end
 		end
+		ret
 	end
-end
-
-
-#
-# when update diary, update cache
-#
-add_update_proc do
-	if /^(append|replace)$/ =~ @mode
-		cache = @category_cache
-		list = []
-		diary = @diaries[@date.strftime('%Y%m%d')]
-		diary.each_section do |s|
-			list |= s.categories
-		end
-		cache.add_categories(list)
-		cache.replace_sections(diary)
-	end
-end
-
-
-#
-# configuration
-#
-def category_icon_find_icons
-   return if @category_all_icon
-	@category_all_icon = []
-	%w(png jpg gif bmp).each do |e|
-		@category_all_icon += Dir.glob("#{@category_icon_dir}*.#{e}".untaint).map {|i| File.basename(i)}
-	end
-	@category_all_icon.sort!
-end
-
-def category_icon_select(category)
-	options = %Q|<\t<option value="none">#{@category_icon_none_label}</option>\n|
-	@category_all_icon.each do |i|
-		options << %Q|\t<option value="#{h i}"#{" selected" if @category_icon[category] == i}>#{h i}</option>\n|
-	end
-	<<HTML
-<select name="category.icon.#{h category}">
-#{options}
-</select>
-HTML
-end
-
-def category_icon_sample
-	@category_all_icon.map do |i|
-		%Q|<img src="#{h @category_icon_url}#{h i}" alt="#{h i}" title="#{h i}">\n|
-	end.join("/\n")
 end
 
 if @mode == 'conf' || @mode == 'saveconf'
-	add_conf_proc( 'category', @category_conf_label, 'basic' ) do
+	add_conf_proc('category', @category_conf_label, 'basic') do
 		if @mode == 'saveconf'
-			if @cgi.valid?( 'category_initialize' )
-				@category_cache.recreate(@years)
-			end
-
-			[
-				'category.header1',
-				'category.header2',
-			].each do |name|
-				@conf[name] = @conf.to_native( @cgi.params[name][0] )
-			end
-			[
-				'category.prev_year',
-				'category.next_year',
-				'category.prev_half',
-				'category.next_half',
-				'category.prev_quarter',
-				'category.next_quarter',
-				'category.prev_month',
-				'category.next_month',
-				'category.this_year',
-				'category.this_half',
-				'category.this_quarter',
-				'category.this_month',
-				'category.all_diary',
-				'category.all_category',
-				'category.all',
-			].each do |name|
-				@conf[name] = @conf.to_native( @cgi.params[name][0] )
-			end
-			if ["month", "quarter", "half", "year", "all"].index(@cgi.params["category.period"][0])
-				@conf["category.period"] = @cgi.params["category.period"][0]
-			end
+			category_rebuild(@years) if @cgi.valid?('category_initialize')
 			@conf['category.edit_support'] = (@cgi.params['category.edit_support'][0] || '1').to_i
 		end
 		category_conf_html
 	end
-
-	category_icon_find_icons if @cgi.params['conf'][0] == 'category_icon'
-	add_conf_proc( 'category_icon', @category_icon_conf_label, 'basic' ) do
-		if @mode == 'saveconf'
-			unless @conf.secure
-				[
-					'category.icon_dir',
-					'category.icon_url',
-				].each do |name|
-					@conf[name] = @cgi.params[name][0].sub(%r|/*$|, '/')
-				end
-				category_icon_location_init
-			end
-			@cgi.params.keys.each do |key|
-				next unless /\Acategory\.icon\..*\z/ === key
-				category = key.sub(/\Acategory\.icon\./, '')
-				if @cgi.params[key][0] == 'none'
-					@category_icon.delete(category)
-				else
-					@category_icon[category] = @cgi.params[key][0]
-				end
-			end
-			category_icon_save
-		end
-		category_icon_conf_html
-	end
-end
-
-@categories = @category_cache.restore_categories.sort_by{|e| e.downcase}
-if @mode == 'categoryview'
-	info = Category::Info.new(@cgi, @years, @conf)
-	@categorized = @category_cache.categorize(info.category, info.years)
 end
 
 # Local Variables:

--- a/misc/plugin/category_legacy.rb
+++ b/misc/plugin/category_legacy.rb
@@ -1,0 +1,744 @@
+#
+# category_legacy.rb : tDiary plugin for show category pages
+#                      legacy version for ruby 2.0 or later
+#
+# Copyright (c) 2003 Junichiro KITA <kita@kitaj.no-ip.com>
+# Distributed under the GPL2 or any later version.
+#
+
+#
+# initialize
+#
+def category_init
+	@conf['category.header1'] ||= %Q[<div class="adminmenu">\n<p>\n<%= category_navi %>\n</p>\n</div>\n]
+	@conf['category.header2'] ||= %Q[<p>Categories |\n<%= category_list %>\n</p>\n]
+	@conf['category.edit_support'] = @conf['category.edit_support'].to_i rescue 1
+end
+category_init
+
+def category_icon_location_init
+	@category_icon_dir = (@conf['category.icon_dir'] || './icons/').sub(%r|/*$|, '/')
+	@category_icon_url = (@conf['category.icon_url'] || './icons/').sub(%r|/*$|, '/')
+end
+
+def category_icon_init
+	category_icon_location_init
+	@conf['category.icon'] ||= ''
+
+	@category_icon = {}
+	@conf['category.icon'].split(/\n/).each do |l|
+		c, i = l.split
+		next if c.nil? or i.nil?
+		@category_icon[c] = i if File.exist?("#{@category_icon_dir}#{i}".untaint)
+	end
+end
+category_icon_init
+
+#
+# plugin methods
+#
+def category_form
+	# don't you need this method any more?
+end
+
+def category_anchor(category)
+	period = @conf['category.period'] || 'quarter'
+	period_string =
+		case period
+		when "month"
+			"year=#{@date.year};month=#{'%02d' % @date.month};"
+		when "quarter"
+			"year=#{@date.year};month=#{(@date.month - 1) / 3 + 1}Q;"
+		when "half"
+			"year=#{@date.year};month=#{(@date.month - 1) / 6 + 1}H;"
+		when "year"
+			"year=#{@date.year};"
+		else
+			""
+		end
+	if @category_icon[category]
+		%Q|<a href="#{h @index}?#{period_string}category=#{u category}" title="#{h category}"><img class="category" src="#{h @category_icon_url}#{h @category_icon[category]}" alt="#{h category}"></a>|
+	else
+		%Q|[<a href="#{h @index}?#{period_string}category=#{u category}" title="#{h category}">#{h category}</a>]|
+	end
+end
+
+def category_navi_anchor(info, label)
+	((!label.nil?) && label.empty?) ? '' : %Q[<span class="adminmenu">#{info.make_anchor(label)}</span>\n]
+end
+
+def category_navi
+	info = Category::Info.new(@cgi, @years, @conf)
+	mode = info.mode
+
+	result = ''
+	case mode
+	when :year, :half, :quarter, :month
+		all_diary = Category::Info.new(@cgi, @years, @conf, year: -1, month: -1)
+		all = Category::Info.new(@cgi, @years, @conf, category: ['ALL'], year: -1, month: -1)
+		result << category_navi_anchor(info.prev, @conf['category.prev_' + mode.to_s])
+		result << category_navi_anchor(info.next, @conf['category.next_' + mode.to_s])
+		result << category_navi_anchor(all_diary, @conf['category.all_diary'])
+		result << category_navi_anchor(all, @conf['category.all'])
+	when :all
+		year = Category::Info.new(@cgi, @years, @conf, year: Time.now.year.to_s)
+		half = Category::Info.new(@cgi, @years, @conf, year: Time.now.year.to_s, month: "#{((Time.now.month - 1) / 6 + 1)}H")
+		quarter = Category::Info.new(@cgi, @years, @conf, year: Time.now.year.to_s, month: "#{((Time.now.month - 1) / 3 + 1)}Q")
+		month = Category::Info.new(@cgi, @years, @conf, year: Time.now.year.to_s, month: '%02d' % Time.now.month)
+		result << category_navi_anchor(year, @conf['category.this_year'])
+		result << category_navi_anchor(half, @conf['category.this_half'])
+		result << category_navi_anchor(quarter, @conf['category.this_quarter'])
+		result << category_navi_anchor(month, @conf['category.this_month'])
+	end
+	if !info.category.include?('ALL') then
+		all_category = Category::Info.new(@cgi, @years, @conf, category: ['ALL'])
+		result << category_navi_anchor(all_category, @conf['category.all_category'])
+	end
+	result
+end
+
+def category_list_sections
+	info = Category::Info.new(@cgi, @years, @conf)
+	r = ''
+
+	raise ::TDiary::NotFound if @categorized.empty? and bot?
+
+	@categorized.to_a.sort_by{|e| e[0].downcase}.each do |c, v|
+		info.category = [c]
+		if @category_icon[c]
+			img = %Q|<img class="category" src="#{h @category_icon_url}#{h @category_icon[c]}" alt="#{h c}">|
+		else
+			img = ''
+		end
+		r << <<HTML
+<div class="category day">
+	<h2><span class="title">#{img}#{info.make_anchor}</span></h2>
+	<div class="body">
+		<ul class="category">
+HTML
+		v.to_a.sort_by{|e| e[0]}.each do |ymd, ary|
+			text = Time.local(ymd[0,4], ymd[4,2], ymd[6,2]).strftime(@conf.date_format)
+			ary.sort.each do |idx, title, excerpt|
+				r << %Q|\t\t\t<li><a href="#{h @index}#{anchor "#{ymd}#p#{'%02d' % idx}"}" title="#{h excerpt}">#{text}#p#{'%02d' % idx}</a> #{apply_plugin(title)}</li>\n|
+			end
+		end
+		r << <<HTML
+		</ul>
+	</div>
+</div>
+HTML
+	end
+	r
+end
+
+def category_list_sections_mobile
+	info = Category::Info.new(@cgi, @years, @conf)
+	r = ''
+
+	raise ::TDiary::NotFound if @categorized.empty? and bot?
+
+	@categorized.to_a.sort_by{|e| e[0].downcase}.each do |c, v|
+		info.category = [c]
+		r << "<H2>#{info.make_anchor}</H2>"
+		r << "<UL>"
+		v.to_a.sort_by{|e| e[0]}.each do |ymd, ary|
+			text = Time.local(ymd[0,4], ymd[4,2], ymd[6,2]).strftime(@conf.date_format)
+			ary.sort.each do |idx, title, excerpt|
+				r << %Q|<LI><A HREF="#{h @index}#{anchor "#{ymd}#p#{'%02d' % idx}"}">#{text}#p#{'%02d' % idx}</A> #{apply_plugin(title)}</LI>\n|
+			end
+		end
+		r << "</UL>"
+	end
+	r
+end
+
+def category_list
+	info = Category::Info.new(@cgi, @years, @conf)
+	@categories.map do |c|
+		info.category = [c]
+		info.make_anchor
+	end.join(" | \n")
+end
+
+def category_dropdown_list(label = nil, multiple = nil)
+	label ||= 'Categorize!'
+	multiple ||= false
+
+	info = Category::Info.new(@cgi, @years, @conf)
+	category = info.category
+	if category.empty?
+		category = ['ALL']
+	end
+
+	options = ''
+	(['ALL'] + @categories).each do |c|
+		options << %Q|\t\t<option value="#{h c}"#{" selected" if category.include?(c)}>#{h c}</option>\n|
+	end
+
+	params = ''
+	params << %Q[<input type="hidden" name="year" value="#{h info.year}">] if info.year
+	params << %Q[<input type="hidden" name="month" value="#{h info.month}">] if info.month
+
+	<<HTML
+<form method="get" action="#{h @index}"><div>
+	<select name="category"#{" multiple" if multiple}>
+#{options}
+	</select>
+	#{params}
+	<input type="submit" value="#{label}">
+</div></form>
+HTML
+end
+
+
+#
+# misc
+#
+
+def category_icon_save
+	@conf['category.icon'] = @category_icon.map {|c, i| "#{c} #{i}"}.join("\n")
+end
+
+
+module Category
+
+#
+# Info
+#
+class Info
+	include ERB::Util
+
+	def initialize(cgi, years, conf, args = {})
+		@cgi = cgi
+		@years = years
+		@conf = conf
+		@category = args[:category] || @cgi.params['category'].map do |c|
+			@conf.to_native(c, @conf.encoding_old)
+		end
+		@year = args[:year] || @cgi.params['year'][0]
+		@month = args[:month] || @cgi.params['month'][0]
+		@mode = :all
+		set_mode
+	end
+
+protected
+	attr_writer :year
+	attr_writer :month
+public
+	attr :category, true
+	attr_reader :year
+	attr_reader :month
+	attr_reader :mode
+
+	def prev
+		pp = self.dup
+
+		case mode
+		when :half
+			h = @month.to_i
+			if h == 1
+				pp.month = "2H"
+				pp.year = (@year.to_i - 1).to_s if @year
+			else
+				pp.month = "1H"
+			end
+		when :quarter
+			q = @month.to_i
+			if q == 1
+				pp.month = "4Q"
+				pp.year = (@year.to_i - 1).to_s if @year
+			else
+				pp.month = "#{q - 1}Q"
+			end
+		when :month
+			m = @month.to_i
+			if m == 1
+				pp.month = "12"
+				pp.year = (@year.to_i - 1).to_s if @year
+			else
+				pp.month = '%02d' % (m - 1)
+			end
+		when :year
+			pp.year = (@year.to_i - 1).to_s
+		end
+		pp
+	end
+
+	def next
+		pp = self.dup
+
+		case mode
+		when :half
+			h = @month.to_i
+			if h == 2
+				pp.month = "1H"
+				pp.year = (@year.to_i + 1).to_s if @year
+			else
+				pp.month = "2H"
+			end
+		when :quarter
+			q = @month.to_i
+			if q == 4
+				pp.month = "1Q"
+				pp.year = (@year.to_i + 1).to_s if @year
+			else
+				pp.month = "#{q + 1}Q"
+			end
+		when :month
+			m = @month.to_i
+			if m == 12
+				pp.month = "01"
+				pp.year = (@year.to_i + 1).to_s if @year
+			else
+				pp.month = '%02d' % (m + 1)
+			end
+		when :year
+			pp.year = (@year.to_i + 1).to_s
+		end
+		pp
+	end
+
+	def make_anchor(label = nil)
+		a = @category.map {|c| "category=#{u c}"}.join(';')
+		a << ";year=#{@year}" if @year
+		a << ";month=#{@month}" if @month
+		if label
+			case mode
+			when :year
+				label = label.gsub(/\$1/, @year)
+			when :month, :quarter, :half
+				label = label.gsub(/\$2/, @month)
+				label = label.gsub(/\$1/, @year || '*')
+			end
+		else
+			label = @category.to_a.join(':')
+		end
+		%Q|<a href="#{h @conf.index}?#{h a}">#{h label}</a>|
+	end
+
+	#
+	# return ym_spec
+	#
+	# {"yyyy" => ["mm", ...], ...}
+	#
+	# date spec:
+	#  (1) none               -> all diary
+	#  (2) month=xH           -> all diary in xH of all year
+	#  (3) year=YYYY;month=xH -> all diary in YYYY/xH
+	#  (4) month=xQ           -> all diary in xQ of all year
+	#  (5) year=YYYY;month=xQ -> all diary in YYYY/xQ
+	#  (6) month=MM           -> all diary in MM of all year
+	#  (7) year=YYYY;month=MM -> all diary in YYYY/MM
+	#  (8) year=YYYY          -> all diary in YYYY
+	#
+	def years
+		if @mode == :all
+			return @years
+		end
+
+		months = case @mode
+		when :half
+			[('01'..'06'), ('07'..'12')][@month.to_i - 1].to_a
+		when :quarter
+			[['01', '02', '03'], ['04', '05', '06'], ['07', '08', '09'], ['10', '11', '12']][@month.to_i - 1]
+		when :month
+			[@month]
+		else
+			('01'..'12').to_a
+		end
+
+		r = {}
+		(@year ? [@year] : @years.keys).each do |y|
+			r[y] = months
+		end
+		r
+	end
+
+	#
+	# date spec:
+	#  (1) none                -> all
+	#  (2) month=xH            -> half
+	#  (3) year=YYYY;month=xH  -> half
+	#  (4) month=xQ            -> quarter
+	#  (5) year=YYYY;month=xQ  -> quarter
+	#  (6) month=MM            -> month
+	#  (7) year=YYYY;month=MM  -> month
+	#  (8) year=YYYY           -> year
+	#
+	def set_mode
+		if @year.nil? and @month.nil?
+			@mode = :all
+		end
+
+		if /\d{4}/ === @year.to_s
+			@mode = :year
+		else
+			@year = nil
+		end
+
+		if /[12]H/ === @month.to_s
+			@mode = :half
+		elsif /[1-4]Q/ === @month.to_s
+			@mode = :quarter
+		elsif (1..12).include?(@month.to_i)
+			@mode = :month
+		else
+			@month = nil
+		end
+
+	end
+end
+
+#
+# Cache
+#
+class Cache
+	include ERB::Util
+
+	def initialize(conf, bind)
+		@conf = conf
+		@binding = bind                           # ...... very ugly
+		@plugin = @binding.eval('self')
+		@categories = nil
+	end
+
+	def get(db, cat)
+		JSON.load(db.get(cat) || '{}')
+	end
+
+	def set(db, cat, data)
+		db.set(cat, data.to_json)
+	end
+
+	def add_categories(list)
+		return if list.nil? or list.empty?
+		replace_categories(restore_categories + list)
+	end
+
+	def replace_categories(list)
+		@categories = list
+	end
+
+	def restore_categories
+		return @categories if @categories
+		@plugin.__send__(:transaction, 'category') do |db|
+			@categories = db.keys
+		end
+		return @categories
+	end
+
+	#
+	# cache each section of diary
+	# used in update_proc
+	#
+	def replace_sections(diary)
+		return if diary.nil? or !diary.categorizable?
+
+		categorized = categorize_diary(diary)
+		categories = restore_categories
+		deleted = []
+		ymd = diary.date.strftime('%Y%m%d')
+
+		@plugin.__send__(:transaction, 'category') do |db|
+			categories.each do |c|
+				cat = get(db, c) || {}
+				if diary.visible? and categorized[c]
+					cat.update(categorized[c])
+					set(db, c, cat)
+				else
+					# diary is invisible or sections of this category is deleted
+					cat.delete(ymd)
+					if cat.empty?
+						db.delete(c)
+						deleted << c
+					else
+						set(db, c, cat)
+					end
+				end
+			end
+
+			if !deleted.empty?
+				replace_categories(categories - deleted)
+			end
+		end
+	end
+
+	#
+	# (re)create category cache
+	#
+	def recreate(years)
+		list = []
+		@plugin.__send__(:transaction, 'category') do |db|
+			db.keys.each {|key|db.delete(key)}
+
+			years.each do |y, ms|
+				ms.each do |m|
+					m = DiaryContainer::find_by_month(@conf, "#{y}#{m}")
+					m.diaries.each do |ymd, diary|
+						next if !diary.visible? or !diary.categorizable?
+						categorized = categorize_diary(diary)
+						categorized.keys.each do |c|
+							cat = get(db, c) || {}
+							set(db, c, cat.update(categorized[c]))
+						end
+						diary.each_section do |s|
+							list |= s.categories unless s.categories.empty?
+						end
+					end
+				end
+			end
+		end
+
+		replace_categories(list)
+	end
+
+	#
+	# categorize sections of category of years
+	#
+	# {"category" => {"yyyymmdd" => [[idx, title, excerpt], ...], ...}, ...}
+	#
+	def categorize(category, years)
+		categories = category - ['ALL']
+		if categories.empty?
+			categories = restore_categories
+		else
+			categories &= restore_categories
+		end
+
+		categorized = {}
+		begin
+			categorized.clear
+			categories.each do |c|
+				@plugin.__send__(:transaction, 'category') do |db|
+					categorized[c] = get(db, c)
+				end
+				categorized[c].keys.each do |ymd|
+					y, m = ymd[0,4], ymd[4,2]
+					if years[y].nil? or !years[y].include?(m)
+						categorized[c].delete(ymd)
+					end
+				end
+				categorized.delete(c) if categorized[c].empty?
+			end
+		rescue NoMethodError	# when categorized[c] is nil
+			recreate(years)
+			retry
+		end
+
+		categorized
+	end
+
+private
+	def cache_file(category = nil)
+		if category
+			"#{@dir}/#{u( category ).gsub(/%20/,'+')}".untaint
+		else
+			"#{@dir}/category_list"
+		end
+	end
+
+	#
+	# categorize sections of diary
+	#
+	# {"category" => {"yyyymmdd" => [[idx, title, excerpt], ...]}}
+	#
+	def categorize_diary(diary)
+		categorized = {}
+		ymd = diary.date.strftime('%Y%m%d')
+
+		idx = 1
+		diary.each_section do |s|
+			s.categories.each do |c|
+				categorized[c] = {} if categorized[c].nil?
+				categorized[c][ymd] = [] if categorized[c][ymd].nil?
+				body = <<EVAL
+text = apply_plugin(<<'BODY', true)
+#{s.body_to_html}
+BODY
+EVAL
+				shorten = begin
+					@conf.shorten(eval(body.untaint, @binding))
+				rescue NameError
+					""
+				end
+				categorized[c][ymd] << [idx, s.stripped_subtitle_to_html, shorten]
+			end
+			idx +=1
+		end
+
+		categorized
+	end
+end
+
+end # module Category
+
+# read cache here so that you can use category with secure mode.
+@category_cache = Category::Cache.new(@conf, binding)
+
+#
+# display categories on update form
+#
+def category_edit_support_flatlist
+	ret = ''
+	ret << '<div class="field title">'
+	ret << "#{@category_conf_label}:\n"
+	@categories.each do |c|
+		ret << %Q!| <span class="category-item">#{h c}</span>\n!
+	end
+	ret << "|\n</div>\n<br>\n"
+	ret
+end
+
+def category_edit_support_dropdown
+	ret = ''
+	ret << '<div class="field title">'
+	ret << %Q|#{@category_conf_label}: <select id="category-candidate" name="category-candidate">\n|
+	@categories.each do |c|
+		ret << %Q!<option>#{h c}</option>\n!
+	end
+	ret << "|\n</select>\n</div>\n<br>\n"
+	ret
+end
+
+if @conf['category.edit_support'] != 0 then
+	enable_js( 'category.js' )
+	add_edit_proc do |date|
+		ret = ''
+		unless @categories.size == 0 then
+			ret << if @conf['category.edit_support'] == 2 then
+				category_edit_support_dropdown
+			else
+				category_edit_support_flatlist
+			end
+		end
+	end
+end
+
+
+#
+# when update diary, update cache
+#
+add_update_proc do
+	if /^(append|replace)$/ =~ @mode
+		cache = @category_cache
+		list = []
+		diary = @diaries[@date.strftime('%Y%m%d')]
+		diary.each_section do |s|
+			list |= s.categories
+		end
+		cache.add_categories(list)
+		cache.replace_sections(diary)
+	end
+end
+
+
+#
+# configuration
+#
+def category_icon_find_icons
+   return if @category_all_icon
+	@category_all_icon = []
+	%w(png jpg gif bmp).each do |e|
+		@category_all_icon += Dir.glob("#{@category_icon_dir}*.#{e}".untaint).map {|i| File.basename(i)}
+	end
+	@category_all_icon.sort!
+end
+
+def category_icon_select(category)
+	options = %Q|<\t<option value="none">#{@category_icon_none_label}</option>\n|
+	@category_all_icon.each do |i|
+		options << %Q|\t<option value="#{h i}"#{" selected" if @category_icon[category] == i}>#{h i}</option>\n|
+	end
+	<<HTML
+<select name="category.icon.#{h category}">
+#{options}
+</select>
+HTML
+end
+
+def category_icon_sample
+	@category_all_icon.map do |i|
+		%Q|<img src="#{h @category_icon_url}#{h i}" alt="#{h i}" title="#{h i}">\n|
+	end.join("/\n")
+end
+
+if @mode == 'conf' || @mode == 'saveconf'
+	add_conf_proc( 'category', @category_conf_label, 'basic' ) do
+		if @mode == 'saveconf'
+			if @cgi.valid?( 'category_initialize' )
+				@category_cache.recreate(@years)
+			end
+
+			[
+				'category.header1',
+				'category.header2',
+			].each do |name|
+				@conf[name] = @conf.to_native( @cgi.params[name][0] )
+			end
+			[
+				'category.prev_year',
+				'category.next_year',
+				'category.prev_half',
+				'category.next_half',
+				'category.prev_quarter',
+				'category.next_quarter',
+				'category.prev_month',
+				'category.next_month',
+				'category.this_year',
+				'category.this_half',
+				'category.this_quarter',
+				'category.this_month',
+				'category.all_diary',
+				'category.all_category',
+				'category.all',
+			].each do |name|
+				@conf[name] = @conf.to_native( @cgi.params[name][0] )
+			end
+			if ["month", "quarter", "half", "year", "all"].index(@cgi.params["category.period"][0])
+				@conf["category.period"] = @cgi.params["category.period"][0]
+			end
+			@conf['category.edit_support'] = (@cgi.params['category.edit_support'][0] || '1').to_i
+		end
+		category_conf_html
+	end
+
+	category_icon_find_icons if @cgi.params['conf'][0] == 'category_icon'
+	add_conf_proc( 'category_icon', @category_icon_conf_label, 'basic' ) do
+		if @mode == 'saveconf'
+			unless @conf.secure
+				[
+					'category.icon_dir',
+					'category.icon_url',
+				].each do |name|
+					@conf[name] = @cgi.params[name][0].sub(%r|/*$|, '/')
+				end
+				category_icon_location_init
+			end
+			@cgi.params.keys.each do |key|
+				next unless /\Acategory\.icon\..*\z/ === key
+				category = key.sub(/\Acategory\.icon\./, '')
+				if @cgi.params[key][0] == 'none'
+					@category_icon.delete(category)
+				else
+					@category_icon[category] = @cgi.params[key][0]
+				end
+			end
+			category_icon_save
+		end
+		category_icon_conf_html
+	end
+end
+
+@categories = @category_cache.restore_categories.sort_by{|e| e.downcase}
+if @mode == 'categoryview'
+	info = Category::Info.new(@cgi, @years, @conf)
+	@categorized = @category_cache.categorize(info.category, info.years)
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:
+# vim: ts=3

--- a/misc/plugin/en/category.rb
+++ b/misc/plugin/en/category.rb
@@ -1,198 +1,40 @@
-# ja/category.rb
+# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2004 Junichiro KITA <kita@kitaj.no-ip.com>
+# en/category.rb : tDiary plugin for show category pages
+#
+# Copyright (C) 2016 TADA Tadashi
 # Distributed under the GPL2 or any later version.
 #
 
-def category_title
-	info = Category::Info.new(@cgi, @years, @conf)
-	mode = info.mode
-	case mode
-	when :year
-		period = "#{info.year}"
-	when :half
-		period = (info.month.to_i == 1 ? "1st half" : "2nd half")
-		period = "#{info.year} #{period}" if info.year
-	when :quarter
-		period = info.month
-		period = "#{info.year}/#{period}" if info.year
-	when :month
-		period = info.month.to_i
-		period = "#{info.year}/#{period}" if info.year
-	end
-	period = " (#{period})" if period
-
-	"[#{info.category.join('|')}#{period}]"
-end
-
-def category_init_local
-	@conf['category.prev_year'] ||= '<< ($1)'
-	@conf['category.next_year'] ||= '($1) >>'
-	@conf['category.prev_half'] ||= '<< ($1-$2)'
-	@conf['category.next_half'] ||= '($1-$2) >>'
-	@conf['category.prev_quarter'] ||= '<< ($1-$2)'
-	@conf['category.next_quarter'] ||= '($1-$2) >>'
-	@conf['category.prev_month'] ||= '<< ($1-$2)'
-	@conf['category.next_month'] ||= '($1-$2) >>'
-	@conf['category.this_year'] ||= 'this year'
-	@conf['category.this_half'] ||= 'this half'
-	@conf['category.this_quarter'] ||= 'this quarter'
-	@conf['category.this_month'] ||= 'this month'
-	@conf['category.all_diary'] ||= 'all diary'
-	@conf['category.all_category'] ||= 'all category'
-	@conf['category.all'] ||= 'all diary/all category'
-end
-category_init_local
-
 @category_conf_label = 'Category'
+
 def category_conf_html
-	r = <<HTML
-<h3 class="subtitle">Create category index</h3>
-<p>
-To use the category feature, you should create category index.
-Check the box below to create category index.
-</p>
-<p><label for="category_initialize">
-<input type="checkbox" id="category_initialize" name="category_initialize" value="1">Rebuild category Index
-</label></p>
-<p>
-It takes several or several tens of second to create it.
-</p>
+	r = <<-HTML
+		<h3 class="subtitle">Build category index</h3>
+		<p>
+		To use the category feature, you should build category index.
+		Check the box below and press OK to build category index.
+		</p>
+		<p><label for="category_initialize">
+		<input type="checkbox" id="category_initialize" name="category_initialize" value="1">Build category index
+		</label></p>
+		<p>
+		It takes several or several tens of second to create it. But your diaries are many or the server has low spec, it will be timeout. Rebuild index on off-line again.
+		</p>
 
-<h3 class="subtitle">Edit Support</h3>
-<p>
-Category names can be shown under the 'Article' form.
-</p>
-<p>
-<select name="category.edit_support">
-<option value="1"#{" selected" if @conf['category.edit_support'] == 1}>Flat List</option>
-<option value="2"#{" selected" if @conf['category.edit_support'] == 2}>Dropdown List/option>
-<option value="0"#{" selected" if @conf['category.edit_support'] == 0}>Hide</option>
-</select>
-</p>
-
-<h3 class="subtitle">Default period</h3>
-<p>
-Specify the default display period for category view.
-</p>
-<p><select name="category.period">
-HTML
-	[
-		['month', 'month', false],
-		['quarter', 'quarter', true],
-		['half-year', 'half', false],
-		['year', 'year', false],
-		['all', 'all', false],
-	].each do |text, value, default|
-		selected = @conf["category.period"] ? @conf["category.period"] == value : default
-		r << <<HTML
-<option value="#{value}"#{" selected" if selected}>#{text}</option>
-HTML
-	end
-	r << <<HTML
-</select></p>
-
-<h3 class="subtitle">Header</h3>
-<p>
-This text is inserted into top of category view.
-"&lt;%= category_navi %&gt;" genaretes navigation buttons for category,
-and "&lt;%= category_list %&gt;" lists all category names.
-You can use plugins and write any HTML tags.
-</p>
-
-<h4>Header 1</h4>
-<p>Inserted under the navigtion buttons.</p>
-<p><textarea name="category.header1" cols="60" rows="8">#{h @conf['category.header1']}</textarea></p>
-
-<h4>Header 2</h4>
-<p>Inserted under the &lt;H1&gt;.</p>
-<p><textarea name="category.header2" cols="60" rows="8">#{h @conf['category.header2']}</textarea></p>
-
-<h3 class="subtitle">Button labels</h3>
-<p>
-Specify button labels.
-$1 and $2 in labels are replaced with year and month.
-</p>
-<table border="0">
-<tr><th>button name</th><th>label</th><th>sample</th></tr>
-HTML
-	[
-		['previous year', 'category.prev_year'],
-		['next year', 'category.next_year'],
-		['previous half', 'category.prev_half'],
-		['next half', 'category.next_half'],
-		['previous quarter', 'category.prev_quarter'],
-		['next quarter', 'category.next_quarter'],
-		['previous month', 'category.prev_month'],
-		['next month', 'category.next_month'],
-		['this year', 'category.this_year'],
-		['this half', 'category.this_half'],
-		['this quarter', 'category.this_quarter'],
-		['this month', 'category.this_month'],
-		['all diary', 'category.all_diary'],
-		['all category', 'category.all_category'],
-		['all diary/all category', 'category.all'],
-	].each do |button, name|
-		r << <<HTML
-<tr>
-	<td>#{button}</td>
-	<td><input type="text" name="#{name}" value="#{h @conf[name]}" size="30"></td>
-	<td><p><span class="adminmenu"><a>#{h @conf[name].sub(/\$1/, "2007").sub(/\$2/, "2")}</a></span></p></td>
-</tr>
-HTML
-	end
-	r << <<HTML
-</table>
-HTML
-end
-
-@category_icon_none_label = 'no icon'
-@category_icon_conf_label = 'Category Icons'
-def category_icon_conf_html
-	r = ''
-	unless @conf.secure
-		r << <<HTML
-<h3 class="subtitle">Location of category icons</h3>
-<p>
-Specify the directory and url of category icons.
-</p>
-<p>
-<dl>
-<dt>Directory:</dt>
-<dd><input name="category.icon_dir" value="#{h @category_icon_dir}" size="30"></dd>
-<dt>URL:</dt>
-<dd><input name="category.icon_url" value="#{h @category_icon_url}" size="30"></dd>
-</dl>
-</p>
-<hr>
-HTML
-   end
-
-	str = ''
-	@categories.each do |c|
-		str << %Q|\t<tr>\n\t\t<td>#{c}</td>\n\t\t<td>\n|
-		str << category_icon_select(c)
-		str << %Q|<img src="#{h @category_icon_url}#{h @category_icon[c]}">| if @category_icon[c]
-		str << %Q|</td>\n\t</tr>\n|
-	end
-	<<HTML
-<h3 class="subtitle">Category Icons</h3>
-<p>
-<table>
-	<tr><th>Category</th><th>Icon</th></tr>
-#{str}
-</table>
-</p>
-<hr>
-<h3 class="subtitle">Sample icons</h3>
-<p>
-You can take your choice from these icons.
-Move mouse pointer on an icon, the icon's name will pop up.
-</p>
-<p>
-#{category_icon_sample}
-</p>
-HTML
+		<h3 class="subtitle">Edit Support</h3>
+		<p>
+		Category names can be shown under the 'Article' form.
+		</p>
+		<p>
+		<select name="category.edit_support">
+		<option value="1"#{" selected" if @conf['category.edit_support'] == 1}>Flat List</option>
+		<option value="2"#{" selected" if @conf['category.edit_support'] == 2}>Dropdown List/option>
+		<option value="0"#{" selected" if @conf['category.edit_support'] == 0}>Hide</option>
+		</select>
+		</p>
+	HTML
+	r
 end
 
 # Local Variables:

--- a/misc/plugin/en/category_legacy.rb
+++ b/misc/plugin/en/category_legacy.rb
@@ -1,0 +1,204 @@
+# en/category_legacy.rb
+#
+# Copyright (c) 2004 Junichiro KITA <kita@kitaj.no-ip.com>
+# Distributed under the GPL2 or any later version.
+#
+
+def category_title
+	info = Category::Info.new(@cgi, @years, @conf)
+	mode = info.mode
+	case mode
+	when :year
+		period = "#{info.year}"
+	when :half
+		period = (info.month.to_i == 1 ? "1st half" : "2nd half")
+		period = "#{info.year} #{period}" if info.year
+	when :quarter
+		period = info.month
+		period = "#{info.year}/#{period}" if info.year
+	when :month
+		period = info.month.to_i
+		period = "#{info.year}/#{period}" if info.year
+	end
+	period = " (#{period})" if period
+
+	"[#{info.category.join('|')}#{period}]"
+end
+
+def category_init_local
+	@conf['category.prev_year'] ||= '<< ($1)'
+	@conf['category.next_year'] ||= '($1) >>'
+	@conf['category.prev_half'] ||= '<< ($1-$2)'
+	@conf['category.next_half'] ||= '($1-$2) >>'
+	@conf['category.prev_quarter'] ||= '<< ($1-$2)'
+	@conf['category.next_quarter'] ||= '($1-$2) >>'
+	@conf['category.prev_month'] ||= '<< ($1-$2)'
+	@conf['category.next_month'] ||= '($1-$2) >>'
+	@conf['category.this_year'] ||= 'this year'
+	@conf['category.this_half'] ||= 'this half'
+	@conf['category.this_quarter'] ||= 'this quarter'
+	@conf['category.this_month'] ||= 'this month'
+	@conf['category.all_diary'] ||= 'all diary'
+	@conf['category.all_category'] ||= 'all category'
+	@conf['category.all'] ||= 'all diary/all category'
+end
+category_init_local
+
+@category_conf_label = 'Category'
+def category_conf_html
+	r = <<HTML
+<h3 class="subtitle">Create category index</h3>
+<p>
+To use the category feature, you should create category index.
+Check the box below to create category index.
+</p>
+<p><label for="category_initialize">
+<input type="checkbox" id="category_initialize" name="category_initialize" value="1">Rebuild category Index
+</label></p>
+<p>
+It takes several or several tens of second to create it.
+</p>
+
+<h3 class="subtitle">Edit Support</h3>
+<p>
+Category names can be shown under the 'Article' form.
+</p>
+<p>
+<select name="category.edit_support">
+<option value="1"#{" selected" if @conf['category.edit_support'] == 1}>Flat List</option>
+<option value="2"#{" selected" if @conf['category.edit_support'] == 2}>Dropdown List/option>
+<option value="0"#{" selected" if @conf['category.edit_support'] == 0}>Hide</option>
+</select>
+</p>
+
+<h3 class="subtitle">Default period</h3>
+<p>
+Specify the default display period for category view.
+</p>
+<p><select name="category.period">
+HTML
+	[
+		['month', 'month', false],
+		['quarter', 'quarter', true],
+		['half-year', 'half', false],
+		['year', 'year', false],
+		['all', 'all', false],
+	].each do |text, value, default|
+		selected = @conf["category.period"] ? @conf["category.period"] == value : default
+		r << <<HTML
+<option value="#{value}"#{" selected" if selected}>#{text}</option>
+HTML
+	end
+	r << <<HTML
+</select></p>
+
+<h3 class="subtitle">Header</h3>
+<p>
+This text is inserted into top of category view.
+"&lt;%= category_navi %&gt;" genaretes navigation buttons for category,
+and "&lt;%= category_list %&gt;" lists all category names.
+You can use plugins and write any HTML tags.
+</p>
+
+<h4>Header 1</h4>
+<p>Inserted under the navigtion buttons.</p>
+<p><textarea name="category.header1" cols="60" rows="8">#{h @conf['category.header1']}</textarea></p>
+
+<h4>Header 2</h4>
+<p>Inserted under the &lt;H1&gt;.</p>
+<p><textarea name="category.header2" cols="60" rows="8">#{h @conf['category.header2']}</textarea></p>
+
+<h3 class="subtitle">Button labels</h3>
+<p>
+Specify button labels.
+$1 and $2 in labels are replaced with year and month.
+</p>
+<table border="0">
+<tr><th>button name</th><th>label</th><th>sample</th></tr>
+HTML
+	[
+		['previous year', 'category.prev_year'],
+		['next year', 'category.next_year'],
+		['previous half', 'category.prev_half'],
+		['next half', 'category.next_half'],
+		['previous quarter', 'category.prev_quarter'],
+		['next quarter', 'category.next_quarter'],
+		['previous month', 'category.prev_month'],
+		['next month', 'category.next_month'],
+		['this year', 'category.this_year'],
+		['this half', 'category.this_half'],
+		['this quarter', 'category.this_quarter'],
+		['this month', 'category.this_month'],
+		['all diary', 'category.all_diary'],
+		['all category', 'category.all_category'],
+		['all diary/all category', 'category.all'],
+	].each do |button, name|
+		r << <<HTML
+<tr>
+	<td>#{button}</td>
+	<td><input type="text" name="#{name}" value="#{h @conf[name]}" size="30"></td>
+	<td><p><span class="adminmenu"><a>#{h @conf[name].sub(/\$1/, "2007").sub(/\$2/, "2")}</a></span></p></td>
+</tr>
+HTML
+	end
+	r << <<HTML
+</table>
+HTML
+end
+
+@category_icon_none_label = 'no icon'
+@category_icon_conf_label = 'Category Icons'
+def category_icon_conf_html
+	r = ''
+	unless @conf.secure
+		r << <<HTML
+<h3 class="subtitle">Location of category icons</h3>
+<p>
+Specify the directory and url of category icons.
+</p>
+<p>
+<dl>
+<dt>Directory:</dt>
+<dd><input name="category.icon_dir" value="#{h @category_icon_dir}" size="30"></dd>
+<dt>URL:</dt>
+<dd><input name="category.icon_url" value="#{h @category_icon_url}" size="30"></dd>
+</dl>
+</p>
+<hr>
+HTML
+   end
+
+	str = ''
+	@categories.each do |c|
+		str << %Q|\t<tr>\n\t\t<td>#{c}</td>\n\t\t<td>\n|
+		str << category_icon_select(c)
+		str << %Q|<img src="#{h @category_icon_url}#{h @category_icon[c]}">| if @category_icon[c]
+		str << %Q|</td>\n\t</tr>\n|
+	end
+	<<HTML
+<h3 class="subtitle">Category Icons</h3>
+<p>
+<table>
+	<tr><th>Category</th><th>Icon</th></tr>
+#{str}
+</table>
+</p>
+<hr>
+<h3 class="subtitle">Sample icons</h3>
+<p>
+You can take your choice from these icons.
+Move mouse pointer on an icon, the icon's name will pop up.
+</p>
+<p>
+#{category_icon_sample}
+</p>
+HTML
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:
+# vim: ts=3

--- a/misc/plugin/ja/category.rb
+++ b/misc/plugin/ja/category.rb
@@ -1,205 +1,41 @@
 # -*- coding: utf-8 -*-
-# ja/category.rb
 #
-# Copyright (c) 2004 Junichiro KITA <kita@kitaj.no-ip.com>
+# ja/category.rb : tDiary plugin for show category pages
+#
+# Copyright (C) 2016 TADA Tadashi
 # Distributed under the GPL2 or any later version.
 #
 
-def category_title
-	info = Category::Info.new(@cgi, @years, @conf)
-	mode = info.mode
-	case mode
-	when :year
-		period = "#{info.year}年"
-	when :half
-		period = (info.month.to_i == 1 ? "上半期" : "下半期")
-		period = "#{info.year}年 #{period}" if info.year
-	when :quarter
-		period = "第#{info.month.to_i}四半期"
-		period = "#{info.year}年 #{period}" if info.year
-	when :month
-		period = "#{info.month.to_i}月"
-		period = "#{info.year}年 #{period}" if info.year
-	end
-	period = " (#{period})" if period
-
-	"[#{info.category.join('|')}#{period}]"
-end
-
-def category_init_local
-	@conf['category.prev_year'] ||= '<< ($1)'
-	@conf['category.next_year'] ||= '($1) >>'
-	@conf['category.prev_half'] ||= '<< ($1-$2)'
-	@conf['category.next_half'] ||= '($1-$2) >>'
-	@conf['category.prev_quarter'] ||= '<< ($1-$2)'
-	@conf['category.next_quarter'] ||= '($1-$2) >>'
-	@conf['category.prev_month'] ||= '<< ($1-$2)'
-	@conf['category.next_month'] ||= '($1-$2) >>'
-	@conf['category.this_year'] ||= '年'
-	@conf['category.this_half'] ||= '半期'
-	@conf['category.this_quarter'] ||= '四半期'
-	@conf['category.this_month'] ||= '月'
-	@conf['category.all_diary'] ||= '全期間'
-	@conf['category.all_category'] ||= '全カテゴリ'
-	@conf['category.all'] ||= '全期間/全カテゴリ'
-end
-category_init_local
-
 @category_conf_label = 'カテゴリ'
+
 def category_conf_html
-	r = <<HTML
-<h3 class="subtitle">カテゴリインデックスの作成</h3>
-<p>
-カテゴリの機能を利用するにはカテゴリインデックスをあらかじめ作成しておく必要があります。
-カテゴリインデックスを作成するには
-以下のチェックを入れてからOKボタンを押してください。
-</p>
-<p><label for="category_initialize">
-<input type="checkbox" id="category_initialize" name="category_initialize" value="1">カテゴリインデックスの作成
-</label></p>
-<p>
-日記の量やサーバの性能にもよりますが、数秒から数十秒でインデックスの作成は終了します。
-</p>
+	r = <<-HTML
+		<h3 class="subtitle">カテゴリインデックスの作成</h3>
+		<p>
+		カテゴリの機能を利用するにはカテゴリインデックスをあらかじめ作成しておく必要があります。
+		カテゴリインデックスを作成するには
+		以下のチェックを入れてからOKボタンを押してください。
+		</p>
+		<p><label for="category_initialize">
+		<input type="checkbox" id="category_initialize" name="category_initialize" value="1">カテゴリインデックスの作成
+		</label></p>
+		<p>
+		数秒から数十秒でインデックスの作成は終了しますが、日記の量が多い場合やサーバの性能が低い場合はタイムアウトしてしまう場合があります。この場合はオフラインで作成して下さい。
+		</p>
 
-<h3 class="subtitle">日記編集サポート</h3>
-<p>
-日記編集画面の「本文」の下にカテゴリ名を一覧表示することができます。
-カテゴリ名をクリックすると「本文」にそのカテゴリ名が挿入されます(要JavaScript)。
-</p>
-<p>
-<select name="category.edit_support">
-<option value="1"#{" selected" if @conf['category.edit_support'] == 1}>一覧表示</option>
-<option value="2"#{" selected" if @conf['category.edit_support'] == 2}>ドロップダウンリスト</option>
-<option value="0"#{" selected" if @conf['category.edit_support'] == 0}>表示しない</option>
-</select>
-</p>
-
-<h3 class="subtitle">表示期間の初期状態</h3>
-<p>
-カテゴリ表示画面を表示した時の、最初の表示期間を指定します。
-</p>
-<p>
-<select name="category.period">
-HTML
-	[
-		['月', 'month', false],
-		['四半期', 'quarter', true],
-		['半期', 'half', false],
-		['年', 'year', false],
-		['全日記', 'all', false],
-	].each do |text, value, default|
-		selected = @conf["category.period"] ? @conf["category.period"] == value : default
-		r << <<HTML
-<option value="#{value}"#{" selected" if selected}>#{text}</option>
-HTML
-	end
-	r << <<HTML
-</select>
-</p>
-
-<h3 class="subtitle">ヘッダ</h3>
-<p>
-画面上部に表示する文章を指定します。
-「&lt;%= category_navi %&gt;」で、カテゴリに特化したナビゲーションボタンを表示することができます。
-また「&lt;%= category_list%&gt;」でカテゴリ名一覧を表示することができます。
-その他，各種プラグインやHTMLを記述できます。
-</p>
-
-<h4>ヘッダ1</h4>
-<p>ナビゲーションボタンのすぐ下に表示されます。</p>
-<p><textarea name="category.header1" cols="60" rows="5">#{h @conf['category.header1']}</textarea></p>
-
-<h4>ヘッダ2</h4>
-<p>H1のすぐ下に表示されます。</p>
-<p><textarea name="category.header2" cols="60" rows="5">#{h @conf['category.header2']}</textarea></p>
-
-<h3 class="subtitle">ボタンラベル</h3>
-<p>
-ナビゲーションボタンのラベルを指定します。
-ラベル中の$1と$2は，それぞれ「年」「月」を表す数値で置換されます。
-</p>
-<table border="0">
-<tr><th>ボタン名</th><th>ラベル</th><th>サンプル</th></tr>
-HTML
-	[
-		['前年', 'category.prev_year'],
-		['翌年', 'category.next_year'],
-		['前の半年', 'category.prev_half'],
-		['次の半年', 'category.next_half'],
-		['前四半期', 'category.prev_quarter'],
-		['次四半期', 'category.next_quarter'],
-		['先月', 'category.prev_month'],
-		['翌月', 'category.next_month'],
-		['今年', 'category.this_year'],
-		['現半期', 'category.this_half'],
-		['現四半期', 'category.this_quarter'],
-		['今月', 'category.this_month'],
-		['全日記', 'category.all_diary'],
-		['全カテゴリ', 'category.all_category'],
-		['全日記/全カテゴリ', 'category.all'],
-	].each do |button, name|
-		r << <<HTML
-<tr>
-	<td>#{button}</td>
-	<td><input type="text" name="#{name}" value="#{h @conf[name]}" size="30"></td>
-	<td><p><span class="adminmenu"><a>#{h @conf[name].sub(/\$1/, "2007").sub(/\$2/, "2")}</a></span></p></td>
-</tr>
-HTML
-	end
-	r << <<HTML
-</table>
-HTML
-end
-
-@category_icon_none_label = 'アイコンなし'
-@category_icon_conf_label = 'カテゴリアイコン'
-def category_icon_conf_html
-	r = ''
-	unless @conf.secure
-		r << <<HTML
-<h3 class="subtitle">カテゴリアイコンの置き場所</h3>
-<p>
-カテゴリアイコン用の画像が保存されているディレクトリとそのURLを指定します。
-</p>
-<p>
-<dl>
-<dt>ディレクトリ:</dt>
-<dd><input name="category.icon_dir" value="#{h @category_icon_dir}" size="30"></dd>
-<dt>URL:</dt>
-<dd><input name="category.icon_url" value="#{h @category_icon_url}" size="30"></dd>
-</dl>
-</p>
-<hr>
-HTML
-	end
-
-	str = ''
-	@categories.each do |c|
-		str << %Q|\t<tr>\n\t\t<td>#{c}</td>\n\t\t<td>\n|
-		str << category_icon_select(c)
-		str << %Q|<img src="#{h @category_icon_url}#{h @category_icon[c]}">| if @category_icon[c]
-		str << %Q|</td>\n\t</tr>\n|
-	end
-	r << <<HTML
-<h3 class="subtitle">カテゴリアイコン</h3>
-<p>
-各カテゴリのアイコンをドロップダウンリストから選択します。
-<p>
-<table>
-	<tr><th>カテゴリ</th><th>アイコン</th></tr>
-#{str}
-</table>
-</p>
-<hr>
-<h3 class="subtitle">アイコンサンプル</h3>
-<p>
-選択可能なアイコン一覧です．
-アイコンにマウスカーソルを合わせるとアイコンのファイル名がポップアップ表示されます。
-</p>
-<p>
-#{category_icon_sample}
-</p>
-HTML
+		<h3 class="subtitle">日記編集サポート</h3>
+		<p>
+		日記編集画面の「本文」の下にカテゴリ名を一覧表示することができます。
+		カテゴリ名をクリックすると「本文」にそのカテゴリ名が挿入されます(要JavaScript)。
+		</p>
+		<p>
+			<select name="category.edit_support">
+				<option value="1"#{" selected" if @conf['category.edit_support'] == 1}>一覧表示</option>
+				<option value="2"#{" selected" if @conf['category.edit_support'] == 2}>ドロップダウンリスト</option>
+				<option value="0"#{" selected" if @conf['category.edit_support'] == 0}>表示しない</option>
+			</select>
+		</p>
+	HTML
 	r
 end
 

--- a/misc/plugin/ja/category_legacy.rb
+++ b/misc/plugin/ja/category_legacy.rb
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+# ja/category_legacy.rb
+#
+# Copyright (c) 2004 Junichiro KITA <kita@kitaj.no-ip.com>
+# Distributed under the GPL2 or any later version.
+#
+
+def category_title
+	info = Category::Info.new(@cgi, @years, @conf)
+	mode = info.mode
+	case mode
+	when :year
+		period = "#{info.year}年"
+	when :half
+		period = (info.month.to_i == 1 ? "上半期" : "下半期")
+		period = "#{info.year}年 #{period}" if info.year
+	when :quarter
+		period = "第#{info.month.to_i}四半期"
+		period = "#{info.year}年 #{period}" if info.year
+	when :month
+		period = "#{info.month.to_i}月"
+		period = "#{info.year}年 #{period}" if info.year
+	end
+	period = " (#{period})" if period
+
+	"[#{info.category.join('|')}#{period}]"
+end
+
+def category_init_local
+	@conf['category.prev_year'] ||= '<< ($1)'
+	@conf['category.next_year'] ||= '($1) >>'
+	@conf['category.prev_half'] ||= '<< ($1-$2)'
+	@conf['category.next_half'] ||= '($1-$2) >>'
+	@conf['category.prev_quarter'] ||= '<< ($1-$2)'
+	@conf['category.next_quarter'] ||= '($1-$2) >>'
+	@conf['category.prev_month'] ||= '<< ($1-$2)'
+	@conf['category.next_month'] ||= '($1-$2) >>'
+	@conf['category.this_year'] ||= '年'
+	@conf['category.this_half'] ||= '半期'
+	@conf['category.this_quarter'] ||= '四半期'
+	@conf['category.this_month'] ||= '月'
+	@conf['category.all_diary'] ||= '全期間'
+	@conf['category.all_category'] ||= '全カテゴリ'
+	@conf['category.all'] ||= '全期間/全カテゴリ'
+end
+category_init_local
+
+@category_conf_label = 'カテゴリ'
+def category_conf_html
+	r = <<HTML
+<h3 class="subtitle">カテゴリインデックスの作成</h3>
+<p>
+カテゴリの機能を利用するにはカテゴリインデックスをあらかじめ作成しておく必要があります。
+カテゴリインデックスを作成するには
+以下のチェックを入れてからOKボタンを押してください。
+</p>
+<p><label for="category_initialize">
+<input type="checkbox" id="category_initialize" name="category_initialize" value="1">カテゴリインデックスの作成
+</label></p>
+<p>
+日記の量やサーバの性能にもよりますが、数秒から数十秒でインデックスの作成は終了します。
+</p>
+
+<h3 class="subtitle">日記編集サポート</h3>
+<p>
+日記編集画面の「本文」の下にカテゴリ名を一覧表示することができます。
+カテゴリ名をクリックすると「本文」にそのカテゴリ名が挿入されます(要JavaScript)。
+</p>
+<p>
+<select name="category.edit_support">
+<option value="1"#{" selected" if @conf['category.edit_support'] == 1}>一覧表示</option>
+<option value="2"#{" selected" if @conf['category.edit_support'] == 2}>ドロップダウンリスト</option>
+<option value="0"#{" selected" if @conf['category.edit_support'] == 0}>表示しない</option>
+</select>
+</p>
+
+<h3 class="subtitle">表示期間の初期状態</h3>
+<p>
+カテゴリ表示画面を表示した時の、最初の表示期間を指定します。
+</p>
+<p>
+<select name="category.period">
+HTML
+	[
+		['月', 'month', false],
+		['四半期', 'quarter', true],
+		['半期', 'half', false],
+		['年', 'year', false],
+		['全日記', 'all', false],
+	].each do |text, value, default|
+		selected = @conf["category.period"] ? @conf["category.period"] == value : default
+		r << <<HTML
+<option value="#{value}"#{" selected" if selected}>#{text}</option>
+HTML
+	end
+	r << <<HTML
+</select>
+</p>
+
+<h3 class="subtitle">ヘッダ</h3>
+<p>
+画面上部に表示する文章を指定します。
+「&lt;%= category_navi %&gt;」で、カテゴリに特化したナビゲーションボタンを表示することができます。
+また「&lt;%= category_list%&gt;」でカテゴリ名一覧を表示することができます。
+その他，各種プラグインやHTMLを記述できます。
+</p>
+
+<h4>ヘッダ1</h4>
+<p>ナビゲーションボタンのすぐ下に表示されます。</p>
+<p><textarea name="category.header1" cols="60" rows="5">#{h @conf['category.header1']}</textarea></p>
+
+<h4>ヘッダ2</h4>
+<p>H1のすぐ下に表示されます。</p>
+<p><textarea name="category.header2" cols="60" rows="5">#{h @conf['category.header2']}</textarea></p>
+
+<h3 class="subtitle">ボタンラベル</h3>
+<p>
+ナビゲーションボタンのラベルを指定します。
+ラベル中の$1と$2は，それぞれ「年」「月」を表す数値で置換されます。
+</p>
+<table border="0">
+<tr><th>ボタン名</th><th>ラベル</th><th>サンプル</th></tr>
+HTML
+	[
+		['前年', 'category.prev_year'],
+		['翌年', 'category.next_year'],
+		['前の半年', 'category.prev_half'],
+		['次の半年', 'category.next_half'],
+		['前四半期', 'category.prev_quarter'],
+		['次四半期', 'category.next_quarter'],
+		['先月', 'category.prev_month'],
+		['翌月', 'category.next_month'],
+		['今年', 'category.this_year'],
+		['現半期', 'category.this_half'],
+		['現四半期', 'category.this_quarter'],
+		['今月', 'category.this_month'],
+		['全日記', 'category.all_diary'],
+		['全カテゴリ', 'category.all_category'],
+		['全日記/全カテゴリ', 'category.all'],
+	].each do |button, name|
+		r << <<HTML
+<tr>
+	<td>#{button}</td>
+	<td><input type="text" name="#{name}" value="#{h @conf[name]}" size="30"></td>
+	<td><p><span class="adminmenu"><a>#{h @conf[name].sub(/\$1/, "2007").sub(/\$2/, "2")}</a></span></p></td>
+</tr>
+HTML
+	end
+	r << <<HTML
+</table>
+HTML
+end
+
+@category_icon_none_label = 'アイコンなし'
+@category_icon_conf_label = 'カテゴリアイコン'
+def category_icon_conf_html
+	r = ''
+	unless @conf.secure
+		r << <<HTML
+<h3 class="subtitle">カテゴリアイコンの置き場所</h3>
+<p>
+カテゴリアイコン用の画像が保存されているディレクトリとそのURLを指定します。
+</p>
+<p>
+<dl>
+<dt>ディレクトリ:</dt>
+<dd><input name="category.icon_dir" value="#{h @category_icon_dir}" size="30"></dd>
+<dt>URL:</dt>
+<dd><input name="category.icon_url" value="#{h @category_icon_url}" size="30"></dd>
+</dl>
+</p>
+<hr>
+HTML
+	end
+
+	str = ''
+	@categories.each do |c|
+		str << %Q|\t<tr>\n\t\t<td>#{c}</td>\n\t\t<td>\n|
+		str << category_icon_select(c)
+		str << %Q|<img src="#{h @category_icon_url}#{h @category_icon[c]}">| if @category_icon[c]
+		str << %Q|</td>\n\t</tr>\n|
+	end
+	r << <<HTML
+<h3 class="subtitle">カテゴリアイコン</h3>
+<p>
+各カテゴリのアイコンをドロップダウンリストから選択します。
+<p>
+<table>
+	<tr><th>カテゴリ</th><th>アイコン</th></tr>
+#{str}
+</table>
+</p>
+<hr>
+<h3 class="subtitle">アイコンサンプル</h3>
+<p>
+選択可能なアイコン一覧です．
+アイコンにマウスカーソルを合わせるとアイコンのファイル名がポップアップ表示されます。
+</p>
+<p>
+#{category_icon_sample}
+</p>
+HTML
+	r
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:
+# vim: ts=3

--- a/spec/acceptance/view_category_spec.rb
+++ b/spec/acceptance/view_category_spec.rb
@@ -25,7 +25,7 @@ BODY
 
 		visit '/'
 		page.find('a', text: "category").click
-		expect(page).to have_content 'Categories'
+		expect(page).to have_content '[category]'
 	end
 end
 


### PR DESCRIPTION
仕様をシンプルにして軽量化したあたらしいcategoryプラグイン(contrib収録のcategory-liteプラグイン)で、categoryプラグインを置き換える。旧categoryはその構造に依存したプラグインが存在するため、category_legacyとして残す。