### PR TITLE
古い bundler と新しい rubygems で travis が落ちる問題の修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ cache:
 bundler_args: "--without server --jobs=3 --retry=3"
 
 before_install:
+  - gem update bundler --no-document
   - "echo 'gemspec' > Gemfile.local"
 
 before_script:


### PR DESCRIPTION
https://travis-ci.org/tdiary/tdiary-core/jobs/117615876 で ruby-head のテストが落ちているので `gem update bundler` してみます。