### PR TITLE
Performance Improvement of `Default::IO#calendar`

### DIFF
--- a/benchmark/benchmark_io_default.rb
+++ b/benchmark/benchmark_io_default.rb
@@ -1,0 +1,52 @@
+$:.unshift 'lib'
+
+require 'benchmark/ips'
+
+require 'tdiary'
+require 'tdiary/cache/file'
+require 'tdiary/io/default'
+
+class DummyTDiary
+	attr_accessor :conf
+
+	def initialize
+		@conf = DummyConf.new
+		@conf.data_path = TDiary.root + "/tmp/"
+	end
+
+	def ignore_parser_cache
+		false
+	end
+end
+
+class DummyConf
+	attr_accessor :data_path
+
+	def cache_path
+		TDiary.root + "/tmp/cache"
+	end
+
+	def options
+		{}
+	end
+
+	def style
+		"wiki"
+	end
+end
+
+conf = DummyConf.new
+conf.data_path = TDiary.root + '/tmp/data/'
+diary = DummyTDiary.new
+diary.conf = conf
+io = TDiary::IO::Default.new(diary)
+
+Benchmark.ips do |x|
+	x.report('calendar') do
+		io.calendar
+	end
+
+	x.report('calendar2') do
+		io.calendar2
+	end
+end

--- a/benchmark/benchmark_io_default.rb
+++ b/benchmark/benchmark_io_default.rb
@@ -1,10 +1,23 @@
-$:.unshift 'lib'
+module TDiary
+	PATH = File::dirname( __FILE__ ).untaint
+	class << self
+		def root
+			File.expand_path(File.join(library_root, '..'))
+		end
 
-require 'benchmark/ips'
+		# directory where tDiary libraries is located
+		def library_root
+			File.expand_path('..', __FILE__)
+		end
 
-require 'tdiary'
-require 'tdiary/cache/file'
-require 'tdiary/io/default'
+		# directory where the server was started
+		def server_root
+			Dir.pwd.untaint
+		end
+	end
+end
+require_relative '../lib/tdiary/cache/file'
+require_relative '../lib/tdiary/io/default'
 
 class DummyTDiary
 	attr_accessor :conf
@@ -40,6 +53,8 @@ conf.data_path = TDiary.root + '/tmp/data/'
 diary = DummyTDiary.new
 diary.conf = conf
 io = TDiary::IO::Default.new(diary)
+
+require 'benchmark/ips'
 
 Benchmark.ips do |x|
 	x.report('calendar') do

--- a/lib/tdiary/io/default.rb
+++ b/lib/tdiary/io/default.rb
@@ -232,11 +232,12 @@ module TDiary
 			end
 
 			def calendar2
-				calendar = Hash.new([])
+				calendar = {}
 				Dir["#{@data_path}????/??????.td2"].sort.each do |file|
-					year, month = file.scan( %r[/(\d{4})(\d\d)\.td2$] )[0]
-					next unless year
-					calendar[year] << month
+					if file =~ /(\d{4})(\d{2})\.td2$/
+						calendar[$1] = [] unless calendar[$1]
+						calendar[$1] << $2
+					end
 				end
 				calendar
 			end

--- a/lib/tdiary/io/default.rb
+++ b/lib/tdiary/io/default.rb
@@ -219,20 +219,6 @@ module TDiary
 
 			def calendar
 				calendar = {}
-				Dir["#{@data_path}????"].sort.each do |dir|
-					next unless %r[/\d{4}$] =~ dir
-					Dir["#{dir.untaint}/??????.td2"].sort.each do |file|
-						year, month = file.scan( %r[/(\d{4})(\d\d)\.td2$] )[0]
-						next unless year
-						calendar[year] = [] unless calendar[year]
-						calendar[year] << month
-					end
-				end
-				calendar
-			end
-
-			def calendar2
-				calendar = {}
 				Dir["#{@data_path}????/??????.td2"].sort.each do |file|
 					if file =~ /(\d{4})(\d{2})\.td2$/
 						calendar[$1] = [] unless calendar[$1]

--- a/lib/tdiary/io/default.rb
+++ b/lib/tdiary/io/default.rb
@@ -232,11 +232,10 @@ module TDiary
 			end
 
 			def calendar2
-				calendar = {}
+				calendar = Hash.new([])
 				Dir["#{@data_path}????/??????.td2"].sort.each do |file|
 					year, month = file.scan( %r[/(\d{4})(\d\d)\.td2$] )[0]
 					next unless year
-					calendar[year] = [] unless calendar[year]
 					calendar[year] << month
 				end
 				calendar

--- a/lib/tdiary/io/default.rb
+++ b/lib/tdiary/io/default.rb
@@ -231,6 +231,20 @@ module TDiary
 				calendar
 			end
 
+			def calendar2
+				calendar = {}
+				Dir["#{@data_path}????"].sort.each do |dir|
+					next unless %r[/\d{4}$] =~ dir
+					Dir["#{dir.untaint}/??????.td2"].sort.each do |file|
+						year, month = file.scan( %r[/(\d{4})(\d\d)\.td2$] )[0]
+						next unless year
+						calendar[year] = [] unless calendar[year]
+						calendar[year] << month
+					end
+				end
+				calendar
+			end
+
 			def cache_dir
 				@tdiary.conf.cache_path || "#{@data_path}/cache"
 			end

--- a/lib/tdiary/io/default.rb
+++ b/lib/tdiary/io/default.rb
@@ -233,14 +233,11 @@ module TDiary
 
 			def calendar2
 				calendar = {}
-				Dir["#{@data_path}????"].sort.each do |dir|
-					next unless %r[/\d{4}$] =~ dir
-					Dir["#{dir.untaint}/??????.td2"].sort.each do |file|
-						year, month = file.scan( %r[/(\d{4})(\d\d)\.td2$] )[0]
-						next unless year
-						calendar[year] = [] unless calendar[year]
-						calendar[year] << month
-					end
+				Dir["#{@data_path}????/??????.td2"].sort.each do |file|
+					year, month = file.scan( %r[/(\d{4})(\d\d)\.td2$] )[0]
+					next unless year
+					calendar[year] = [] unless calendar[year]
+					calendar[year] << month
 				end
 				calendar
 			end


### PR DESCRIPTION
呼び出される回数が多い `Default::IO#calendar` を速くしました。

```
    % ruby benchmark_io_default.rb
    Warming up --------------------------------------
                calendar    16.000  i/100ms
               calendar2    22.000  i/100ms
    Calculating -------------------------------------
                calendar    195.073  (±14.9%) i/s -    960.000  in   5.070197s
               calendar2    237.695  (±13.9%) i/s -      1.166k in   5.039136s
```

おおよそ、10-15% 速くなっています。