### PR TITLE
use MONGODB_URI environment variable instead of MONGOLAB_URI

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2016-04-26  TADA Tadashi <t@tdtds.jp>
+	* heroku/tdiary.conf: use MONGODB_URI environment variable instead of MONGOLAB_URI
+
 2016-04-19  MATSUOKA Kohei <kohei@machu.jp>
 	* Dockerfile: support docker
 

--- a/misc/paas/heroku/tdiary.conf
+++ b/misc/paas/heroku/tdiary.conf
@@ -7,7 +7,7 @@ require 'tempfile'
 @style = 'Wiki'
 
 @io_class = TDiary::IO::MongoDB
-@database_url = ENV['MONGOLAB_URI']
+@database_url = ENV['MONGODB_URI'] || ENV['MONGOLAB_URI']
 
 @index = './'
 @update = 'update.rb'


### PR DESCRIPTION
HerokuのmLab addonが設定するMongoDBのURIが、環境変数「MONGOLAB_URI」から「MONGODB_URI」に変更になったので、MONGODB_URIを優先して使うように変更。互換性維持のために引き続き「MONGOLAB_URI」も参照している。