### PR TITLE
OGP headers provided by default plugin lacks some properties. 

### DIFF
--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -331,14 +331,27 @@ def default_ogp
 		uri = @conf.index.dup
 		uri[0, 0] = base_url if %r|^https?://|i !~ @conf.index
 		uri.gsub!( %r|/\./|, '/' )
-		image = File.join(uri, "#{theme_url}/ogimage.png")
+		image = @conf.banner.nil? ? File.join(uri, "#{theme_url}/ogimage.png") : @conf.banner
+		ogp = {
+			'og:title' => title_tag.gsub(/<[^>]*>/, ""),
+			'og:image' => (h image),
+		}
+		ogp['fb:app_id'] = @conf['ogp.facebook.app_id']
+		ogp['fb:admins'] = @conf['ogp.facebook.admins']
 		if @mode == 'day' then
-			uri += anchor( @date.strftime( '%Y%m%d' ) )
+			ogp['og:type'] = 'article'
+			ogp['article:author'] = @conf.author_name
+			ogp['og:site_name'] = @conf.html_title
+			ogp['og:url'] = h(uri + anchor( @date.strftime( '%Y%m%d' ) ))
+		else
+			ogp['og:type'] = 'website'
+			ogp['og:description'] = h(@conf.description)
+			ogp['og:url'] = h(uri)
 		end
-		%Q[<meta content="#{title_tag.gsub(/<[^>]*>/, "")}" property="og:title">
-		<meta content="#{(@mode == 'day') ? 'article' : 'website'}" property="og:type">
-		<meta content="#{h image}" property="og:image">
-		<meta content="#{h uri}" property="og:url">]
+
+		ogp.map { |k, v|
+			%Q|<meta property="#{k}" content="#{v}">|
+		}.join("\n")
 	end
 end
 


### PR DESCRIPTION
[The result of Open Graph Object debugger](https://developers.facebook.com/tools/debug/og/object/?q=https%3A%2F%2Fsatoryu-diary.herokuapp.com%2F) says that `og:description` should be specified for the top page of a tDiary. 
The ogp headers are provided by the default plugin: `lib/tdiary/plugin/00default.rb` without ogp plugin packed in tdiary/tdiary-conrib. 

The scope of this PR is to fix the default plugin so that the warning messages go. 