### PR TITLE
remove sprockets from release package

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,15 @@
 source 'https://rubygems.org'
 
 gem 'rack'
-gem 'sprockets'
 gem 'hikidoc'
 gem 'fastimage'
 gem 'emot'
 gem 'mail'
 gem 'rake'
+
+group :rack do
+  gem 'sprockets'
+end
 
 group :development do
   gem 'pit', require: false

--- a/lib/tdiary/environment.rb
+++ b/lib/tdiary/environment.rb
@@ -11,7 +11,7 @@ require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 $LOAD_PATH.each{|lp| $LOAD_PATH << $LOAD_PATH.shift.dup.untaint}
 
 if defined?(Bundler)
-  env = [:default]
+  env = [:default, :rack]
   env << :development if ENV['RACK_ENV'].nil? || ENV['RACK_ENV'].empty?
   env << ENV['RACK_ENV'].intern if ENV['RACK_ENV']
   env = env.reject{|e| Bundler.settings.without.include? e }

--- a/lib/tdiary/tasks/release.rake
+++ b/lib/tdiary/tasks/release.rake
@@ -34,7 +34,7 @@ def make_tarball( repo, version = nil )
 			sh "chmod +x index.rb index.fcgi update.rb update.fcgi"
 			sh 'rake doc'
 			Bundler.with_clean_env do
-					sh "bundle --path .bundle --without development:test"
+					sh "bundle --path .bundle --without rack:development:test"
 			end
 
 			# reduce filesize


### PR DESCRIPTION
tDiaryのパッケージ版からsproketsライブラリを取り除く提案です。

cygwin+CGI環境でtdiary5.0.0が起動しない問題 (#569) で、CGI環境では使わないsprockets関連の読み込みに失敗しているので、パッケージ版はなるべく依存関係をなくして配布したほうが良いと思いました。

副作用として、rack環境ではパッケージ版を使えなくなります。いちおう[公式ドキュメント](https://github.com/tdiary/tdiary-core/blob/master/doc/INSTALL-rack.md)には、rack環境ではtdiary gemを使うようにしているので影響ないと思いますが。