### PR TITLE
tDiaryの依存ライブラリをtdiary.gemspecに記述する

### DIFF
--- a/lib/tdiary/environment.rb
+++ b/lib/tdiary/environment.rb
@@ -17,3 +17,19 @@ if defined?(Bundler)
   env = env.reject{|e| Bundler.settings.without.include? e }
   Bundler.require *env
 end
+
+# Bundler.require doesn't load gems specified in .gemspec
+# see: https://github.com/bundler/bundler/issues/1041
+#
+# load gems dependented by tdiary
+tdiary_spec = Bundler.definition.specs.find {|spec| spec.name == 'tdiary'}
+if tdiary_spec
+  tdiary_spec.dependent_specs.each {|dep_spec|
+    begin
+      require dep_spec.name
+    rescue LoadError => e
+      STDERR.puts "failed require '#{dep_spec.name}'"
+      STDERR.puts e
+    end
+  }
+end

--- a/tdiary.gemspec
+++ b/tdiary.gemspec
@@ -35,6 +35,13 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1.0'
 
-  spec.add_dependency 'thor', '~> 0.18'
+  spec.add_dependency 'emot'
+  spec.add_dependency 'fastimage'
+  spec.add_dependency 'hikidoc'
+  spec.add_dependency 'mail'
+  spec.add_dependency 'rack'
+  spec.add_dependency 'rake'
+  spec.add_dependency 'sprockets'
+  spec.add_dependency 'thor'
   spec.add_dependency "bundler", "~> 1.3"
 end


### PR DESCRIPTION
tdiaryをgem経由で使うときに、いまだとtDiaryの依存ライブラリを外部のGemfileにも書かなければいけません。tdiary.gemspecにも依存ライブラリを書いておくことで、外部のGemfileではgem 'tdiary'`とだけ書けば良くなります。

たとえば、 tdiary/tdiary-io-mongodbに付属のtdiary-mongodb-convertを動かすときや、tdiary/tdiary-orgのようにtDiaryを`gem 'tdiary'`として読み込んで使う時に、emotなどの依存ライブラリをGemfileに書かなくて良くなるのが嬉しいです

本当はtdiary-coreをgitで取得してそのまま動かす場合もtdiary.gemspecを使うようにしたいのですが、Herokuで動かない問題 (#527) があるので今はこのままです。