### PR TITLE
Cannot use core assets when TDiary::Extension was already declared

### DIFF
--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -1,4 +1,5 @@
 require 'tdiary'
+require 'tdiary/extensions/core'
 require 'rack/builder'
 require 'tdiary/rack'
 

--- a/lib/tdiary/extensions.rb
+++ b/lib/tdiary/extensions.rb
@@ -1,5 +1,3 @@
-require 'tdiary/extensions/core'
-
 module TDiary
   module Extensions
   end


### PR DESCRIPTION
tdiary-coreとtdiary-blogkitの組み合わせで、core側のassetが見えなくなる問題を修正しました。`tdiary/extensions/core` を明示的に呼び出すようにしています。

 * see: tdiary/tdiary-blogkit#8