### PR TITLE
Fixed nil references when item metadata could not fetch from amazon api

### DIFF
--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -69,6 +69,10 @@ class AmazonItem
 			@item.elements.to_a(path)
 		end
 	end
+
+  def has_item?
+    !@item.nil?
+  end
 end
 
 def amazon_fetch( url, limit = 10 )
@@ -289,11 +293,11 @@ def amazon_get( asin, with_image = true, label = nil, pos = 'amazon' )
 	rescue NoMethodError
 		message = label || asin
 		if @mode == 'preview' then
-			if item == nil then
+			if item.has_item? then
+				message << %Q|<span class="message">(#{h $!}\n#{h $@.join( ' / ' )})</span>|
+			else
 				m = item.nodes( 'Items/Request/Errors/Error/Message' )[0].text
 				message << %Q|<span class="message">(#{h @conf.to_native( m, 'utf-8' )})</span>|
-			else
-				message << %Q|<span class="message">(#{h $!}\n#{h $@.join( ' / ' )})</span>|
 			end
 		end
 		message


### PR DESCRIPTION
Fixed https://github.com/tdiary/tdiary-core/issues/579

以前の実装では item をまず node として取り出してから item が空の時に別の node として保存されているエラーメッセージを取り出していましたが、`AmazonItem`に統合した時の対応漏れで #579 のようなエラーを出していました。

以前と同等の処理となるように `AmazonItem`の中で item が取れているかどうかを判定し、失敗している場合は改めて node を参照して取り出すような処理に変えました。

@tdtds 以前の実装と、こう変えたという部分のコードを見てもらってよいでしょうか。