### PR TITLE
Ruby 1.9 以降で使える Hash syntax に揃える

### DIFF
--- a/lib/tdiary/cli.rb
+++ b/lib/tdiary/cli.rb
@@ -103,11 +103,11 @@ module TDiary
 
 			if options[:cgi]
 				opts = {
-					:daemon => ENV['DAEMON'],
-					:bind   => options[:bind],
-					:port   => options[:port],
-					:logger => $stderr,
-					:access_log => options[:log] ? File.open(options[:log], 'a') : $stderr
+					daemon: ENV['DAEMON'],
+					bind: options[:bind],
+					port: options[:port],
+					logger: $stderr,
+					access_log: options[:log] ? File.open(options[:log], 'a') : $stderr
 				}
 				TDiary::Server.run( opts )
 			elsif
@@ -116,12 +116,12 @@ module TDiary
 				require 'webrick'
 				ARGV.shift
 				opts = {
-					:environment => ENV['RACK_ENV'] || "development",
-					:daemonize   => false,
-					:Host        => options[:bind],
-					:Port        => options[:port],
-					:pid         => File.expand_path("tdiary.pid"),
-					:config      => File.expand_path("config.ru")
+					environment: ENV['RACK_ENV'] || "development",
+					daemonize: false,
+					Host: options[:bind],
+					Port: options[:port],
+					pid: File.expand_path("tdiary.pid"),
+					config: File.expand_path("config.ru")
 				}
 				if options[:log]
 					opts[:AccessLog] = [[File.open(options[:log], 'a'), WEBrick::AccessLog::CLF]]

--- a/lib/tdiary/dispatcher.rb
+++ b/lib/tdiary/dispatcher.rb
@@ -7,8 +7,8 @@ module TDiary
 		autoload :UpdateMain, 'tdiary/dispatcher/update_main'
 
 		TARGET = {
-			:index => IndexMain,
-			:update => UpdateMain
+			index: IndexMain,
+			update: UpdateMain
 		}
 
 		def initialize( target )

--- a/lib/tdiary/server.rb
+++ b/lib/tdiary/server.rb
@@ -29,13 +29,13 @@ module TDiary
 
 		def initialize( opts )
 			@server = WEBrick::HTTPServer.new(
-				:Port => opts[:port], BindAddress: opts[:bind],
-				:DocumentRoot => TDiary.root,
-				:MimeTypes => tdiary_mime_types,
-				:Logger => webrick_logger_to( opts[:logger] ),
-				:AccessLog => webrick_access_log_to( opts[:access_log] ),
-				:ServerType => opts[:daemon] ? WEBrick::Daemon : nil,
-				:CGIInterpreter => WEBrick::HTTPServlet::CGIHandler::Ruby
+				Port: opts[:port], BindAddress: opts[:bind],
+				DocumentRoot: TDiary.root,
+				MimeTypes: tdiary_mime_types,
+				Logger: webrick_logger_to( opts[:logger] ),
+				AccessLog: webrick_access_log_to( opts[:access_log] ),
+				ServerType: opts[:daemon] ? WEBrick::Daemon : nil,
+				CGIInterpreter: WEBrick::HTTPServlet::CGIHandler::Ruby
 			)
 			@server.logger.level = WEBrick::Log::DEBUG
 			@server.mount("/", WEBrick::HTTPServlet::CGIHandler, TDiary.root + "/index.rb")

--- a/lib/tdiary/style/wiki.rb
+++ b/lib/tdiary/style/wiki.rb
@@ -84,11 +84,11 @@ module TDiary
 
 			def to_html( string )
 				html = HikiDoc::to_html( string,
-					:level => 3,
-					:empty_element_suffix => '>',
-					:use_wiki_name => false,
-					:allow_bracket_inline_image => false,
-					:plugin_syntax => method(:valid_plugin_syntax?) ).strip
+					level: 3,
+					empty_element_suffix: '>',
+					use_wiki_name: false,
+					allow_bracket_inline_image: false,
+					plugin_syntax: method(:valid_plugin_syntax?) ).strip
 				html.gsub!( %r!<span class="plugin">\{\{(.+?)\}\}</span>!m ) do
 					"<%=#{CGI.unescapeHTML($1)}\n%>"
 				end

--- a/spec/plugin/bq_spec.rb
+++ b/spec/plugin/bq_spec.rb
@@ -14,7 +14,7 @@ describe "bq plugin w/" do
 		end
 
 		it { expect(@body_snippet).to eq(expected_html_body(
-				:src => 'foo')) }
+				src: 'foo')) }
 	end
 
 	def expected_html_body(options)


### PR DESCRIPTION
`synvert -rruby/new_hash_syntax` を使って `{:foo => :bar}` を `{foo: :bar}` に置換しました。

単なる style change なので CI 通過後にマージします