### PR TITLE
define img.right and img.left after img.photo

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2016-08-23  TADA Tadashi <t@tdtds.jp>
+	* base.css, default.css: define img.right and img.left after img.photo
+
 2016-06-30  TADA Tadashi <t@tdtds.jp>
 	* skip loading octokit on production mode in Rakefile
 

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = '5.0.1'
+	VERSION = '5.0.1.20160823'
 end

--- a/theme/base.css
+++ b/theme/base.css
@@ -119,6 +119,11 @@ span.amazon-label, span.amazon-price {
 /*
 image plugin
 */
+img.photo {
+	float: right;
+	margin: 0.5em;
+}
+
 img.left {
 	float: left;
 	margin: 0.5em;
@@ -129,11 +134,6 @@ img.right, img.amazon {
 	float: right;
 	margin: 0.5em;
 	margin-top: 0px;
-}
-
-img.photo {
-	float: right;
-	margin: 0.5em;
 }
 
 /*

--- a/theme/default/default.css
+++ b/theme/default/default.css
@@ -212,22 +212,24 @@ div.section img {
 	border-width: 1px;
 }
 
+div.section img.photo {
+	display: block;
+	float: none;
+	margin: 0px auto;
+	margin-bottom: 10px;
+}
+
 div.section img.right, img.amazon {
+	display: inline;
 	float: right;
 	margin-left: 10px;
 	margin-bottom: 10px;
 }
 
 div.section img.left {
+	display: inline;
 	float: left;
 	margin-right: 10px;
-	margin-bottom: 10px;
-}
-
-div.section img.photo {
-	display: block;
-	float: none;
-	margin: 0px auto;
 	margin-bottom: 10px;
 }
 


### PR DESCRIPTION
flickrプラグインが他の画像系プラグインと異なり、同一要素に`img.left` / `img.right`と`img.photo`の両方のクラスを指定するが、`img.photo`の方があとに定義されているテーマだと画像が左寄せ/右寄せされない。

flickrプラグインの挙動は間違っていない(むしろ好ましい)ので、`img.photo`の定義を`img.left` / `img.right`よりも前にした。