### PR TITLE
[WIP] specify dependencies in the gemspec file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rack', '~> 1.6' # ~> 2.0 requires ruby 2.2.2 or later.
-gem 'hikidoc'
-gem 'fastimage'
-gem 'emot'
-gem 'mail'
-gem 'rake'
+gemspec
 
 group :rack do
   gem 'sprockets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       fastimage
       hikidoc
       mail
-      rack
+      rack (~> 1.6)
       rake
       sprockets
       thor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+PATH
+  remote: .
+  specs:
+    tdiary (5.0.2)
+      bundler (~> 1.3)
+      emot
+      fastimage
+      hikidoc
+      mail
+      rack
+      rake
+      sprockets
+      thor
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -129,18 +143,12 @@ PLATFORMS
 DEPENDENCIES
   capybara
   coveralls (~> 0.7.12)
-  emot
-  fastimage
-  hikidoc
   jasmine
   launchy
-  mail
   octokit
   pit
   pry-byebug
-  rack (~> 1.6)
   racksh
-  rake
   redcarpet
   rspec
   selenium-webdriver
@@ -148,7 +156,8 @@ DEPENDENCIES
   simplecov
   sprockets
   sqlite3
+  tdiary!
   test-unit
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/misc/paas/heroku/Gemfile.lock
+++ b/misc/paas/heroku/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/tdiary/tdiary-contrib.git
-  revision: ed1401f47c7b351dcdf933bd3892705b596af76b
+  revision: 1091fddc58b40ddc17a408dd22eb52b461703b98
   specs:
-    tdiary-contrib (5.0.1)
+    tdiary-contrib (5.0.2)
       ruby-pushbullet
       tdiary
 
@@ -13,6 +13,20 @@ GIT
     tdiary-io-mongodb (4.2.0.1)
       hikidoc
       mongoid (~> 5.0)
+
+PATH
+  remote: .
+  specs:
+    tdiary (5.0.2)
+      bundler (~> 1.3)
+      emot
+      fastimage
+      hikidoc
+      mail
+      rack (~> 1.6)
+      rake
+      sprockets
+      thor
 
 GEM
   remote: https://rubygems.org/
@@ -168,9 +182,6 @@ GEM
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sqlite3 (1.3.11)
-    tdiary (5.0.1)
-      bundler (~> 1.3)
-      thor (~> 0.18)
     tdiary-style-gfm (0.4.0)
       emot
       github-markdown
@@ -203,12 +214,8 @@ DEPENDENCIES
   capybara
   coveralls (~> 0.7.12)
   dalli
-  emot
-  fastimage
-  hikidoc
   jasmine
   launchy
-  mail
   memcachier
   octokit
   omniauth
@@ -216,9 +223,7 @@ DEPENDENCIES
   pit
   pry-byebug
   puma
-  rack (~> 1.6)
   racksh
-  rake
   redcarpet
   rspec
   selenium-webdriver
@@ -226,6 +231,7 @@ DEPENDENCIES
   simplecov
   sprockets
   sqlite3
+  tdiary!
   tdiary-contrib!
   tdiary-io-mongodb!
   tdiary-style-gfm
@@ -236,4 +242,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/tdiary.gemspec
+++ b/tdiary.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fastimage'
   spec.add_dependency 'hikidoc'
   spec.add_dependency 'mail'
-  spec.add_dependency 'rack'
+  spec.add_dependency 'rack', '~> 1.6' # ~> 2.0 requires ruby 2.2.2 or later.
   spec.add_dependency 'rake'
   spec.add_dependency 'sprockets'
   spec.add_dependency 'thor'


### PR DESCRIPTION
tDiary本体の依存ライブラリをGemfieではなくtdiary.gemspecで指定します。herokuのビルドに失敗する問題 (#527) が解決しているようなので、改めてPR作りました。

関連
- tdiaryの依存ライブラリをGemfileではなくgemspecに記述する #517
- herokuでのbuildに失敗する #527
- Revert "move essential gems from Gemfile to .gemspec" #529
- tDiaryの依存ライブラリをtdiary.gemspecに記述する #571
