### PR TITLE
Added default value for script filename for fcgi endpoint

### DIFF
--- a/index.fcgi
+++ b/index.fcgi
@@ -25,7 +25,7 @@ FCGI.each_cgi do |cgi|
 		class << CGI; self; end.class_eval do
 			define_method(:new) {|*args| cgi }
 		end
-		dir = File::dirname( cgi.env_table["SCRIPT_FILENAME"] )
+		dir = File::dirname( cgi.env_table["SCRIPT_FILENAME"] || __FILE__ )
 		Dir.chdir(dir) do
 			load 'index.rb'
 		end

--- a/update.fcgi
+++ b/update.fcgi
@@ -25,7 +25,7 @@ FCGI.each_cgi do |cgi|
 		class << CGI; self; end.class_eval do
 			define_method(:new) {|*args| cgi }
 		end
-		dir = File::dirname( cgi.env_table["SCRIPT_FILENAME"] )
+		dir = File::dirname( cgi.env_table["SCRIPT_FILENAME"] || __FILE__ )
 		Dir.chdir(dir) do
 			load 'update.rb'
 		end


### PR DESCRIPTION
h2o のような apache2 以外の http サーバーで fcgi を動かすときに apache2 に依存した環境変数で落ちる箇所を直しました。

具体的には `ENV['SCRIPT_FILENAME']` が h2o では設定されないので、雑に自分自身のパスを渡して、同じディレクトリにある index.rb/update.rb をロードするようにしています。