### PR TITLE
amazon.rb: The clear attribute on the br element is obsolete.

### DIFF
--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -228,7 +228,7 @@ def amazon_detail_html( item )
 			<span class="amazon-author">#{h author}</span><br>
 			<span class="amazon-label">#{h amazon_label( item )}</span><br>
 			<span class="amazon-price">#{h amazon_price( item )}</span>
-		</span><br style="clear: left">
+		</span>
 	</span></a>
 	HTML
 end


### PR DESCRIPTION
AmazonプラグインでHTML5非準拠の記述があったので直しました。
本来はCSSに置き換えるのが正しいようですが、そのまま削除しても問題なさそうです。
（外側の`span.amazon-detail`が`display: block`なので）