### PR TITLE
delete description of xml-rpc library from xmlrpc plugin

### DIFF
--- a/misc/plugin/xmlrpc/xmlrpc.rb
+++ b/misc/plugin/xmlrpc/xmlrpc.rb
@@ -4,7 +4,6 @@
 # Copyright (c) 2004 MoonWolf <moonwolf@moonwolf.com>
 # Distributed under the GPL2 or any later version.
 #
-# require Ruby1.8 or xml-rpc(http://raa.ruby-lang.org/project/xml-rpc/)
 
 BEGIN { $stdout.binmode }
 


### PR DESCRIPTION
#600 派生。xmlrpcライブラリはruby 1.8以降は標準添付なので、入手方法の記述は不要。