### PR TITLE
spam-champuruへの問い合わせでtDiaryが遅くなる問題を修正

### DIFF
--- a/lib/tdiary/filter/spam.rb
+++ b/lib/tdiary/filter/spam.rb
@@ -164,7 +164,7 @@ module TDiary
 			end
 
 			def lookup(domain, dnsbl, iplookup = false)
-				Timeout::timeout(5) do
+				Timeout::timeout(1) do
 					domain = IPSocket::getaddress( domain ).split(/\./).reverse.join(".") if iplookup
 					address = Resolv.getaddress( "#{domain}.#{dnsbl}" )
 					debug("lookup:#{domain}.#{dnsbl} address:#{address}: spam host.")

--- a/lib/tdiary/plugin/10spamfilter.rb
+++ b/lib/tdiary/plugin/10spamfilter.rb
@@ -140,7 +140,7 @@ add_conf_proc( 'dnsblfilter', @dnsblfilter_label_conf, 'security' ) do
 	end
 
 	# initialize IP based DNSBL list
-	@conf['spamlookup.ip.list'] ||= "dnsbl.spam-champuru.livedoor.com"
+	@conf['spamlookup.ip.list'] ||= "bsb.spamlookup.net"
 	auto_migration_spam_champuru
 
 	# initialize DNSBL list
@@ -154,10 +154,12 @@ end
 
 def auto_migration_spam_champuru
 	# auto migration of spam-champuru shutdown.
-	if @conf['spamlookup.ip.list'].scan(/dnsbl\.spam-champuru\.livedoor\.com/).size > 0
+	if @conf['spamlookup.ip.list'] && @conf['spamlookup.ip.list'].scan(/dnsbl\.spam-champuru\.livedoor\.com/).size > 0
 		@conf['spamlookup.ip.list'].gsub!(/dnsbl\.spam-champuru\.livedoor\.com/, "bsb.spamlookup.net")
 	end
 end
+
+auto_migration_spam_champuru
 
 # Local Variables:
 # mode: ruby


### PR DESCRIPTION
ローカル環境のtDiaryが遅い（応答に5秒以上かかる）現象があり、調べるとspam-champuruへの問い合わせがタイムアウトになる5秒間待機していました。
#276 でspam-champuruのサービス終了へ対応していますが、SPAMフィルタの設定画面を開かないとマイグレーションが有効にならないため、古い設定が残ったままでした。

対策として、以下を修正しました。

 * 常にDNSマイグレーションを実行する
 * DNS問い合わせのタイムアウト時間を5秒から1秒に短縮