### PR TITLE
amp.rb: fix bug, plugin does not work in gem mode

### DIFF
--- a/misc/plugin/amp.rb
+++ b/misc/plugin/amp.rb
@@ -15,7 +15,8 @@ end
 
 add_content_proc('amp') do |date|
   diary = @diaries[date]
-  ERB.new(File.read("views/amp.rhtml")).result(binding)
+  template = File.read(File.join(TDiary::root, "views/amp.rhtml"))
+  ERB.new(template).result(binding)
 end
 
 def amp_body(diary)


### PR DESCRIPTION
tDiaryをgemでインストールした場合に、AMPプラグインが動かない問題を修正しました。