### PR TITLE
fix amphtml URL for '?date=YYYYMMDD' style diary

### DIFF
--- a/misc/plugin/amp.rb
+++ b/misc/plugin/amp.rb
@@ -35,7 +35,7 @@ end
 
 def amp_html_url(diary)
   uri = amp_canonical_url(diary)
-  uri.query = [uri.query, "plugin=amp"].join '&'
+  uri.query = [uri.query, "plugin=amp"].compact.join '&'
   uri
 end
 

--- a/misc/plugin/amp.rb
+++ b/misc/plugin/amp.rb
@@ -35,7 +35,7 @@ end
 
 def amp_html_url(diary)
   uri = amp_canonical_url(diary)
-  uri.query = [uri.query, "?plugin=amp"].join '&'
+  uri.query = [uri.query, "plugin=amp"].join '&'
   uri
 end
 

--- a/misc/plugin/amp.rb
+++ b/misc/plugin/amp.rb
@@ -34,7 +34,9 @@ def amp_day_title(diary)
 end
 
 def amp_html_url(diary)
-  URI.join(amp_canonical_url(diary), '?plugin=amp')
+  uri = amp_canonical_url(diary)
+  uri.query = [uri.query, "?plugin=amp"].join '&'
+  uri
 end
 
 def amp_style


### PR DESCRIPTION
amp.rb プラグインで amphtml がおかしい問題 #613 を修正していました。
レビューをお願い申し上げます。
`spec/plugin/amp_spec.rb` は書き方がよくわからなかったのでつけませんでした。すみません。

