### PR TITLE
insert theme location (local or online) into @theme in tdiary.conf

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2017-01-16  TADA Tadashi <t@tdtds.jp>
+	* insert theme location (local or online) into @theme in tdiary.conf
+
 2017-01-04  TADA Tadashi <t@tdtds.jp>
 	* heroku/Gemfile.local: change some gem source to "https" instead of "github"
 

--- a/lib/tdiary/configuration.rb
+++ b/lib/tdiary/configuration.rb
@@ -171,6 +171,7 @@ module TDiary
 			@show_nyear = false unless @show_nyear
 
 			@theme = 'default' if not @theme and not @css
+			@theme = "local/#{@theme}" unless @theme.index('/')
 			@css = '' unless @css
 
 			@show_comment = true unless defined?( @show_comment )

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -411,6 +411,7 @@ def css_tag
 	elsif @conf.theme and @conf.theme.length > 0
 		location, name = @conf.theme.split(%r[/], 2)
 		css = __send__("theme_url_#{location}", name)
+		css = theme_url_local('default') # the location is not defined
 	else
 		css = @conf.css
 	end

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -411,7 +411,7 @@ def css_tag
 	elsif @conf.theme and @conf.theme.length > 0
 		location, name = @conf.theme.split(%r[/], 2)
 		css = __send__("theme_url_#{location}", name)
-		css = theme_url_local('default') # the location is not defined
+		css = theme_url_local('default') unless css # the location is not defined
 	else
 		css = @conf.css
 	end

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -409,11 +409,7 @@ def css_tag
 	if @mode =~ /conf$/ then
 		css = "#{h theme_url}/conf.css"
 	elsif @conf.theme and @conf.theme.length > 0
-		location, name = @conf.theme.split(/\//, 2)
-		unless name
-			name = location
-			location = 'local'
-		end
+		location, name = @conf.theme.split(%r[/], 2)
 		css = __send__("theme_url_#{location}", name)
 	else
 		css = @conf.css

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = '5.0.3'
+	VERSION = '5.0.3.20170116'
 end


### PR DESCRIPTION
`tdiary.conf`読み込み時に、テーマの場所(現在は`local`か`online`)の情報を`@theme`に確実に入れる。プラグインはこの情報が`@theme`に含まれることを期待して良い。