### PR TITLE
revert to support ruby 2.4 to 2.3 on Heroku

### DIFF
--- a/misc/paas/heroku/Gemfile.local
+++ b/misc/paas/heroku/Gemfile.local
@@ -1,4 +1,4 @@
-ruby '~> 2.4.0'
+ruby '~> 2.3.0'
 gem 'puma', require: false
 gem 'tdiary-io-mongodb', git: 'https://github.com/tdiary/tdiary-io-mongodb.git'
 gem 'tdiary-contrib', git: 'https://github.com/tdiary/tdiary-contrib.git'

--- a/misc/paas/heroku/Gemfile.lock
+++ b/misc/paas/heroku/Gemfile.lock
@@ -28,14 +28,14 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     bson (4.2.1)
     byebug (9.0.6)
-    capybara (2.11.0)
+    capybara (2.12.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    childprocess (0.5.9)
+    childprocess (0.6.1)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.1)
     concurrent-ruby (1.0.4)
@@ -58,11 +58,11 @@ GEM
       addressable (~> 2)
     ffi (1.9.17)
     github-markdown (0.6.9)
-    hashie (3.4.6)
+    hashie (3.5.1)
     hikidoc (0.1.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.7.0)
+    i18n (0.8.0)
     jasmine (2.5.1)
       jasmine-core (>= 2.5.1, < 3.0.0)
       phantomjs
@@ -81,9 +81,9 @@ GEM
     minitest (5.10.1)
     mongo (2.4.1)
       bson (>= 4.2.1, < 5.0.0)
-    mongoid (6.0.3)
+    mongoid (6.1.0)
       activemodel (~> 5.0)
-      mongo (~> 2.3)
+      mongo (>= 2.4.1, < 3.0.0)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     netrc (0.11.0)
@@ -92,18 +92,18 @@ GEM
     oauth (0.5.1)
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
-    omniauth (1.3.2)
+    omniauth (1.4.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
     omniauth-oauth (1.1.0)
       oauth
       omniauth (~> 1.0)
-    omniauth-twitter (1.3.0)
+    omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
     phantomjs (2.1.1.0)
     pit (0.0.7)
-    power_assert (0.4.1)
+    power_assert (1.0.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -112,7 +112,7 @@ GEM
       byebug (~> 9.0)
       pry (~> 0.10)
     public_suffix (2.0.5)
-    puma (3.6.2)
+    puma (3.7.0)
     rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -143,15 +143,15 @@ GEM
     ruby-pushbullet (0.1.4)
       json
       rest-client (~> 1.8.0)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    selenium-webdriver (3.0.5)
+    selenium-webdriver (3.0.8)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    sequel (4.42.1)
+    sequel (4.43.0)
     simplecov (0.9.2)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
@@ -185,7 +185,7 @@ GEM
       power_assert
     thor (0.19.4)
     thread_safe (0.3.5)
-    tins (1.13.0)
+    tins (1.13.2)
     twitter-text (1.14.5)
       unf (~> 0.1.0)
     tzinfo (1.2.2)
@@ -193,7 +193,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
-    websocket (1.2.3)
+    websocket (1.2.4)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -234,7 +234,7 @@ DEPENDENCIES
   test-unit
 
 RUBY VERSION
-   ruby 2.4.0p0
+   ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.7
+   1.14.3


### PR DESCRIPTION
mongo gemがruby 2.4.0で動かないので、Heroku向けのGemfile.localでruby 2.4を指定するのをいったんやめる。ruby 2.4.1では修正されているので、それを待って戻す。