### PR TITLE
fix ignore @css by theme location in tdiary.conf

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2017-02-09  TADA Tadashi <t@tdtds.jp>
+	* fix: ignore @css by theme location in tdiary.conf
+
 2017-01-20  TADA Tadashi <t@tdtds.jp>
 	* support ruby 2.4.0
 	* drop ruby 2.1

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -406,10 +406,10 @@ def theme_url
 end
 
 def css_tag
+	location, name = (@conf.theme || '').split(%r[/], 2)
 	if @mode =~ /conf$/ then
 		css = "#{h theme_url}/conf.css"
-	elsif @conf.theme and @conf.theme.length > 0
-		location, name = @conf.theme.split(%r[/], 2)
+	elsif name && name.length > 0
 		css = __send__("theme_url_#{location}", name)
 		css = theme_url_local('default') unless css # the location is not defined
 	else

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = '5.0.3.20170116'
+	VERSION = '5.0.3.20170209'
 end


### PR DESCRIPTION
#616 でエンバグした @css が有効にならない問題を修正