### PR TITLE
enable pry-byebug at MRI 2.1 or higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 services: memcache
 
 rvm:
-  - 2.2
+  - 2.2.6
   - 2.3.3
   - 2.4.0
   - ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development do
   gem 'octokit'
 
   group :test do
-    gem 'pry-byebug', platforms: [:ruby_20, :ruby_21]
+    gem 'pry-byebug', platforms: [:ruby_21, :ruby_22, :ruby_23, :ruby_24]
     gem 'test-unit'
     gem 'rspec'
     gem 'capybara', require: 'capybara/rspec'


### PR DESCRIPTION
最近のRubyでもpry-byebugが動くようにしました。