### PR TITLE
fix multiple og:image meta tags

### DIFF
--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -210,7 +210,7 @@ add_header_proc do
 	#{author_mail_tag}
 	#{index_page_tag}
 	#{icon_tag}
-	#{default_ogp}
+	#{ogp_tag}
 	#{description_tag}
 	#{css_tag.chomp}
 	#{jquery_tag.chomp}
@@ -322,7 +322,7 @@ def icon_tag
 	end
 end
 
-def default_ogp
+def ogp_tag
 	uri = @conf.index.dup
 	uri[0, 0] = base_url if %r|^https?://|i !~ @conf.index
 	uri.gsub!( %r|/\./|, '/' )

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -331,8 +331,6 @@ def default_ogp
 		'og:title' => title_tag.gsub(/<[^>]*>/, ""),
 		'og:image' => image,
 	}
-	ogp['fb:app_id'] = @conf['ogp.facebook.app_id']
-	ogp['fb:admins'] = @conf['ogp.facebook.admins']
 	if @mode == 'day' then
 		ogp['og:type'] = 'article'
 		ogp['article:author'] = @conf.author_name

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -323,36 +323,30 @@ def icon_tag
 end
 
 def default_ogp
-	if @conf.options2['sp.selected'] && @conf.options2['sp.selected'].include?('ogp.rb')
-		if !defined?(@conf.banner) || @conf.banner == ''
-			%Q[<meta content="#{base_url}images/ogimage.png" property="og:image">]
-		end
+	uri = @conf.index.dup
+	uri[0, 0] = base_url if %r|^https?://|i !~ @conf.index
+	uri.gsub!( %r|/\./|, '/' )
+	image = (@conf.banner.nil? || @conf.banner == '') ? File.join(uri, "#{theme_url}/ogimage.png") : @conf.banner
+	ogp = {
+		'og:title' => title_tag.gsub(/<[^>]*>/, ""),
+		'og:image' => (h image),
+	}
+	ogp['fb:app_id'] = @conf['ogp.facebook.app_id']
+	ogp['fb:admins'] = @conf['ogp.facebook.admins']
+	if @mode == 'day' then
+		ogp['og:type'] = 'article'
+		ogp['article:author'] = @conf.author_name
+		ogp['og:site_name'] = @conf.html_title
+		ogp['og:url'] = h(uri + anchor( @date.strftime( '%Y%m%d' ) ))
 	else
-		uri = @conf.index.dup
-		uri[0, 0] = base_url if %r|^https?://|i !~ @conf.index
-		uri.gsub!( %r|/\./|, '/' )
-		image = (@conf.banner.nil? || @conf.banner == '') ? File.join(uri, "#{theme_url}/ogimage.png") : @conf.banner
-		ogp = {
-			'og:title' => title_tag.gsub(/<[^>]*>/, ""),
-			'og:image' => (h image),
-		}
-		ogp['fb:app_id'] = @conf['ogp.facebook.app_id']
-		ogp['fb:admins'] = @conf['ogp.facebook.admins']
-		if @mode == 'day' then
-			ogp['og:type'] = 'article'
-			ogp['article:author'] = @conf.author_name
-			ogp['og:site_name'] = @conf.html_title
-			ogp['og:url'] = h(uri + anchor( @date.strftime( '%Y%m%d' ) ))
-		else
-			ogp['og:type'] = 'website'
-			ogp['og:description'] = h(@conf.description)
-			ogp['og:url'] = h(uri)
-		end
-
-		ogp.map { |k, v|
-			%Q|<meta property="#{k}" content="#{v}">|
-		}.join("\n")
+		ogp['og:type'] = 'website'
+		ogp['og:description'] = h(@conf.description)
+		ogp['og:url'] = h(uri)
 	end
+
+	ogp.map { |k, v|
+		%Q|<meta property="#{k}" content="#{v}">|
+	}.join("\n")
 end
 
 def description_tag

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -324,7 +324,7 @@ end
 
 def default_ogp
 	if @conf.options2['sp.selected'] && @conf.options2['sp.selected'].include?('ogp.rb')
-		if !defined?(@conf.banner) && @conf.banner != ''
+		if !defined?(@conf.banner) || @conf.banner == ''
 			%Q[<meta content="#{base_url}images/ogimage.png" property="og:image">]
 		end
 	else

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -329,7 +329,7 @@ def default_ogp
 	image = (@conf.banner.nil? || @conf.banner == '') ? File.join(uri, "#{theme_url}/ogimage.png") : @conf.banner
 	ogp = {
 		'og:title' => title_tag.gsub(/<[^>]*>/, ""),
-		'og:image' => (h image),
+		'og:image' => image,
 	}
 	ogp['fb:app_id'] = @conf['ogp.facebook.app_id']
 	ogp['fb:admins'] = @conf['ogp.facebook.admins']
@@ -337,15 +337,15 @@ def default_ogp
 		ogp['og:type'] = 'article'
 		ogp['article:author'] = @conf.author_name
 		ogp['og:site_name'] = @conf.html_title
-		ogp['og:url'] = h(uri + anchor( @date.strftime( '%Y%m%d' ) ))
+		ogp['og:url'] = uri + anchor( @date.strftime( '%Y%m%d' ) )
 	else
 		ogp['og:type'] = 'website'
-		ogp['og:description'] = h(@conf.description)
-		ogp['og:url'] = h(uri)
+		ogp['og:description'] = @conf.description
+		ogp['og:url'] = uri
 	end
 
 	ogp.map { |k, v|
-		%Q|<meta property="#{k}" content="#{v}">|
+		%Q|<meta property="#{k}" content="#{h(v)}">|
 	}.join("\n")
 end
 

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -324,14 +324,14 @@ end
 
 def default_ogp
 	if @conf.options2['sp.selected'] && @conf.options2['sp.selected'].include?('ogp.rb')
-		if defined?(@conf.banner)
+		if !defined?(@conf.banner) && @conf.banner != ''
 			%Q[<meta content="#{base_url}images/ogimage.png" property="og:image">]
 		end
 	else
 		uri = @conf.index.dup
 		uri[0, 0] = base_url if %r|^https?://|i !~ @conf.index
 		uri.gsub!( %r|/\./|, '/' )
-		image = @conf.banner.nil? ? File.join(uri, "#{theme_url}/ogimage.png") : @conf.banner
+		image = (@conf.banner.nil? || @conf.banner == '') ? File.join(uri, "#{theme_url}/ogimage.png") : @conf.banner
 		ogp = {
 			'og:title' => title_tag.gsub(/<[^>]*>/, ""),
 			'og:image' => (h image),


### PR DESCRIPTION
contrib の ogp.rb プラグイン使用時に、どうも `default_ogp` メソッドによって og:image メタタグが2つ生成されてしまうのを修正しようとしています。(1つ目は `default_ogp` メソッドが `<meta content="diary-url/images/ogimage.png" property="og:image">` のようなタグを、そして2つ目に ogp.rb プラグインが本来の og:image タグを生成していて、前者は not found となりfacebookなどでURLを貼ったときに真っ白けになっています。)

元は、`@conf.banner` が `defined?` かどうかをチェックしていたり `.nil?` したりしているのですが、

1. まず https://github.com/tdiary/tdiary-core/blob/master/lib%2Ftdiary%2Fplugin%2F00default.rb#L327 は否定なのではないか? (そうでしょうか?)
2. さらに、`@conf.banner` が `''` だったりすることもあり、`nil` チェックだけではだめなのではないか?

と考えて、ひとまずこのコード変更をしてみています。
ogp.rb プラグインをお使いの方、特にレビューをお願いしたく存じます。
