### PR TITLE
古いtdrファイルを最近のrubyで復旧できるよう修正

### DIFF
--- a/lib/tdiary/io/default.rb
+++ b/lib/tdiary/io/default.rb
@@ -82,7 +82,7 @@ module TDiary
 						fh.read.split( /\r?\n\.\r?\n/ ).each do |l|
 							headers, body = Default.parse_tdiary( l )
 							next unless body
-							body.each do |r|
+							body.lines.each do |r|
 								count, ref = r.chomp.split( / /, 2 )
 								next unless ref
 								diaries[headers['Date']].add_referer( ref.chomp, count.to_i )


### PR DESCRIPTION
古い日記データを以降しようとすると、tdrファイルの解析でこけます。
見ると、ruby1.9以降廃止されたStringへのeachを使っていたので、修正してみました。