### PR TITLE
fix error of amp plugin on the day is empty

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2017-06-15  Tada, Tadashi <t@tdtds.jp>
+	* plugin/amp.rb: fix error on the day was empty
+
 2017-03-29  Tada, Tadashi <t@tdtds.jp>
 	* release 5.0.4
 

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = '5.0.4'
+	VERSION = '5.0.4.20170615'
 end

--- a/misc/plugin/amp.rb
+++ b/misc/plugin/amp.rb
@@ -34,15 +34,23 @@ extend AMP
 
 add_header_proc do
   if @mode == 'day'
-    diary = @diaries[@date.strftime('%Y%m%d')]
-    %Q|<link rel="amphtml" href="#{amp_html_url(diary)}">|
+    begin
+    	diary = @diaries[@date.strftime('%Y%m%d')]
+    	%Q|<link rel="amphtml" href="#{amp_html_url(diary)}">|
+    rescue NoMethodError
+      ''
+    end
   end
 end
 
 add_content_proc('amp') do |date|
-  diary = @diaries[date]
-  template = File.read(File.join(TDiary::root, "views/amp.rhtml"))
-  ERB.new(template).result(binding)
+  begin
+    diary = @diaries[date]
+    template = File.read(File.join(TDiary::root, "views/amp.rhtml"))
+    ERB.new(template).result(binding)
+  rescue NoMethodError
+    raise TDiary::NotFound
+  end
 end
 
 def amp_body(diary)


### PR DESCRIPTION
ampプラグインを有効にした状態で存在しない日の日記を表示するとエラーになります。以下のように修正します:

* 通常表示時にはエラーを無視
* plugin=amp指定時には404を返す