### PR TITLE
Handle Errno::*

### DIFF
--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -125,7 +125,7 @@ def amazon_call_ecs( asin, id_type, country )
 	rescue AmazonRedirectError
 		limit = $!.message.to_i
 		retry
-	rescue ArgumentError
+	rescue ArgumentError, SystemCallError
 	end
 end
 


### PR DESCRIPTION
rpaproxy が `Errno::ECONNREFUSED` を返した時に日記がエラーで表示できなくなってしまうので最低限のハンドリングを入れました。なお、これでも `preview` の時はエラーになります...(あとで)