### PR TITLE
return charset as 'UTF-8' by Content-Type

### DIFF
--- a/lib/tdiary/dispatcher/index_main.rb
+++ b/lib/tdiary/dispatcher/index_main.rb
@@ -21,7 +21,7 @@ module TDiary
 
 					begin
 						head = {
-							'Content-Type' => 'text/html',
+							'Content-Type' => 'text/html; charset=UTF-8',
 							'Vary' => 'User-Agent'
 						}
 						head['status'] = status if status

--- a/lib/tdiary/dispatcher/update_main.rb
+++ b/lib/tdiary/dispatcher/update_main.rb
@@ -20,7 +20,7 @@ module TDiary
 					head = {}; body = ''
 					body = tdiary.eval_rhtml
 					head = {
-						'Content-Type' => 'text/html',
+						'Content-Type' => 'text/html; charset=UTF-8',
 						'charset' => conf.encoding,
 						'Content-Length' => body.bytesize.to_s,
 						'Vary' => 'User-Agent',


### PR DESCRIPTION
全面的にUTF-8へ移行したのにContent-Typeで明示的にcharsetを返していなかったので、返すようにしました。index.rbとupdate.rbの正常系2ヶ所のみ。エラー処理などのところには入れていません。