### PR TITLE
Removed obsoleted rack middleware about coffeescripts.

### DIFF
--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -45,12 +45,6 @@ module TDiary
 							environment.append_path assets_path
 						}
 
-						if TDiary.configuration.options['tdiary.assets.precompile']
-							TDiary.logger.info('enable assets.precompile')
-							require 'tdiary/rack/assets/precompile'
-							use TDiary::Rack::Assets::Precompile, environment
-						end
-
 						run environment
 					end
 				end

--- a/lib/tdiary/rack.rb
+++ b/lib/tdiary/rack.rb
@@ -5,10 +5,6 @@ module TDiary
 		autoload :Session,          'tdiary/rack/session'
 		autoload :Static,           'tdiary/rack/static'
 		autoload :Auth,             'tdiary/rack/auth'
-
-		module Assets
-			autoload :Precompile,    'tdiary/rack/assets/precompile'
-		end
 	end
 end
 


### PR DESCRIPTION
7e9debe691045835b7534224a0249c3cfc2754cf で削除済みだった sprockets を利用して CoffeeScript をトランスパイルする rack middleware への参照が残っていたので削除しました。

これ、明らかに `autoload` でエラーが出ると思うんですが誰も使ってないことがバレてしまった...