### PR TITLE
fix incompatibirity between bundler 1.15 and 1.16

### DIFF
--- a/lib/tdiary/environment.rb
+++ b/lib/tdiary/environment.rb
@@ -14,7 +14,7 @@ if defined?(Bundler)
   env = [:default, :rack]
   env << :development if ENV['RACK_ENV'].nil? || ENV['RACK_ENV'].empty?
   env << ENV['RACK_ENV'].intern if ENV['RACK_ENV']
-  env = env.reject{|e| Bundler.settings.without.include? e }
+  env = env.reject{|e| (Bundler.settings[:without] || []).include? e }
   Bundler.require *env
 end
 

--- a/lib/tdiary/environment.rb
+++ b/lib/tdiary/environment.rb
@@ -14,7 +14,9 @@ if defined?(Bundler)
   env = [:default, :rack]
   env << :development if ENV['RACK_ENV'].nil? || ENV['RACK_ENV'].empty?
   env << ENV['RACK_ENV'].intern if ENV['RACK_ENV']
-  env = env.reject{|e| (Bundler.settings[:without] || []).include? e }
+  env = env.reject{|e|
+	  (Bundler.settings.without rescue Bundler.settings[:without]).include? e
+  }
   Bundler.require *env
 end
 


### PR DESCRIPTION
Bundlerを1.15から1.16 pre2にあげたら非互換で動かないところがあったので、1.15 / 1.16両対応をしてみた

* 従来使っていた`Bundler::Settings#without`は1.16から消えているので代わりに`#[:without]`を使う
* `Bundler::Settings#[]`は1.15で`nil`を返すことがあるのでその場合は`[]`を使う(1.16は空配列を返す)