### PR TITLE
enable debugging in Visual Studio Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "tDiary server",
+            "type": "Ruby",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "program": "${workspaceRoot}/bin/tdiary",
+            "args": [
+                "server"
+            ],
+            "useBundler": true
+        }
+    ]
+}

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ group :development do
   gem 'racksh', require: false
   gem 'redcarpet'
   gem 'octokit'
+  gem 'ruby-debug-ide'
+  gem 'debase'
 
   group :test do
     gem 'pry-byebug', platforms: [:ruby_21, :ruby_22, :ruby_23, :ruby_24]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,9 @@ GEM
       simplecov (~> 0.9.1)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
+    debase (0.2.1)
+      debase-ruby_core_source
+    debase-ruby_core_source (0.9.10)
     diff-lcs (1.3)
     docile (1.1.5)
     domain_name (0.5.20170404)
@@ -90,6 +93,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
+    ruby-debug-ide (0.6.0)
+      rake (>= 0.8.1)
     rubyzip (1.2.1)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
@@ -125,6 +130,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   coveralls (~> 0.7.12)
+  debase
   emot
   fastimage
   hikidoc
@@ -139,6 +145,7 @@ DEPENDENCIES
   rake
   redcarpet
   rspec
+  ruby-debug-ide
   selenium-webdriver
   sequel
   simplecov


### PR DESCRIPTION
Visual Studio CodeエディタでtDiaryをデバッグできるように、デバッグ用のgemと起動用の設定を追加します。

see. https://code.visualstudio.com/docs/editor/debugging