### PR TITLE
fix #654: insecure errors in some plugins using DiaryContainer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2017-12-27  Tada, Tadashi <t@tdtds.jp>
+	* fix insecure errors in some plugins using DiaryContainer
+
 2017-12-22  Tada, Tadashi <t@tdtds.jp>
 	* change document links to GitHub Wiki
 

--- a/lib/tdiary/io/default.rb
+++ b/lib/tdiary/io/default.rb
@@ -6,6 +6,7 @@
 #
 require 'fileutils'
 require 'tdiary/io/base'
+require 'tdiary/comment'
 
 module TDiary
 	TDIARY_MAGIC_MAJOR = 'TDIARY2'

--- a/misc/plugin/category-legacy.rb
+++ b/misc/plugin/category-legacy.rb
@@ -5,6 +5,7 @@
 # Copyright (c) 2003 Junichiro KITA <kita@kitaj.no-ip.com>
 # Distributed under the GPL2 or any later version.
 #
+require 'tdiary/diary_container'
 
 #
 # initialize

--- a/misc/plugin/category.rb
+++ b/misc/plugin/category.rb
@@ -4,7 +4,7 @@
 # Copyright (C) 2016 TADA Tadashi
 # Distributed under the GPL2 or any later version.
 #
-
+require 'tdiary/diary_container'
 
 # read cache here so that you can use category with secure mode.
 @conf['category.header1'] = ''

--- a/misc/plugin/recent_comment3.rb
+++ b/misc/plugin/recent_comment3.rb
@@ -8,6 +8,7 @@ require 'pstore'
 require 'fileutils'
 require 'time'
 require 'pathname'
+require 'tdiary/diary_container'
 
 def recent_comment3_format(format, *args)
 	format.gsub(/\$(\d)/) {|s| args[$1.to_i - 1]}

--- a/misc/plugin/recent_list.rb
+++ b/misc/plugin/recent_list.rb
@@ -15,6 +15,8 @@
 # Copyright (c) 2001,2002 Junichiro KITA <kita@kitaj.no-ip.com>
 # Distributed under the GPL2 or any later version.
 #
+require 'tdiary/diary_container'
+
 module ::TDiary
 	class TDiaryMonthWithoutFilter < TDiaryMonth
 		def referer_filter(referer); end


### PR DESCRIPTION
maybe fix #654 and tdiary/tdiary-blogkit#17

ようするに内部で`DiaryContainer`クラスを使おうとすると`autoload`が走ってセキュリティエラーになる、ということなので、とりあえず明示的に`require`するようにした。