### PR TITLE
update ruby versions on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ bundler_args: "--without server --jobs=3 --retry=3"
 before_install:
   - "echo 'gemspec' > Gemfile.local"
   - echo "gem 'phantomjs', '= 1.9.8.0'" >> Gemfile.local
+  - gem update --system
+  - gem update bundler
   - bundle update phantomjs
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ sudo: false
 services: memcache
 
 rvm:
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
   - ruby-head
 
 matrix:


### PR DESCRIPTION
TravisCIで使うrubyのバージョンをそれぞれ最新にし、2.5.0を追加。