### PR TITLE
Remove `SAFE=1` and `Safe::safe`

### DIFF
--- a/benchmark/benchmark_io_default.rb
+++ b/benchmark/benchmark_io_default.rb
@@ -1,5 +1,5 @@
 module TDiary
-	PATH = File::dirname( __FILE__ ).untaint
+	PATH = File::dirname( __FILE__ )
 	class << self
 		def root
 			File.expand_path(File.join(library_root, '..'))
@@ -12,7 +12,7 @@ module TDiary
 
 		# directory where the server was started
 		def server_root
-			Dir.pwd.untaint
+			Dir.pwd
 		end
 	end
 end

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
-$:.unshift( File.join(File::expand_path(File::dirname( __FILE__ )), 'lib' ).untaint )
+$:.unshift( File.join(File::expand_path(File::dirname( __FILE__ )), 'lib' ) )
 require 'tdiary/application'
 
 use ::Rack::Reloader unless ENV['RACK_ENV'] == 'production'

--- a/index.fcgi
+++ b/index.fcgi
@@ -9,12 +9,12 @@
 #
 require 'fcgi'
 # workaround untaint LOAD_PATH for rubygems library path is always tainted.
-$:.each{|path| path.untaint if path.include?('fcgi') && path.tainted? }
+$:.each{|path| path if path.include?('fcgi') && path.tainted? }
 
 if FileTest::symlink?( __FILE__ ) then
-	org_path = File::dirname( File::readlink( __FILE__ ) ).untaint
+	org_path = File::dirname( File::readlink( __FILE__ ) )
 else
-	org_path = File::dirname( __FILE__ ).untaint
+	org_path = File::dirname( __FILE__ )
 end
 load "#{org_path}/misc/lib/fcgi_patch.rb"
 

--- a/index.fcgi
+++ b/index.fcgi
@@ -9,7 +9,7 @@
 #
 require 'fcgi'
 # workaround untaint LOAD_PATH for rubygems library path is always tainted.
-$:.each{|path| path if path.include?('fcgi') && path.tainted? }
+$:.each{|path| path if path.include?('fcgi') }
 
 if FileTest::symlink?( __FILE__ ) then
 	org_path = File::dirname( File::readlink( __FILE__ ) )

--- a/index.rb
+++ b/index.rb
@@ -14,7 +14,7 @@ begin
 	else
 		org_path = File::dirname( __FILE__ )
 	end
-	$:.unshift( (org_path + '/lib').untaint ) unless $:.include?( org_path + '/lib' )
+	$:.unshift( (org_path + '/lib') ) unless $:.include?( org_path + '/lib' )
 	require 'tdiary'
 
 	encoding_error = {}

--- a/lib/tdiary.rb
+++ b/lib/tdiary.rb
@@ -11,9 +11,9 @@ Encoding::default_external = 'UTF-8'
 require 'tdiary/version'
 TDIARY_VERSION = TDiary::VERSION
 
-$:.unshift File.join(File::dirname(__FILE__), '../misc/lib').untaint
+$:.unshift File.join(File::dirname(__FILE__), '../misc/lib')
 ['../misc/lib/*/lib', '../vendor/*/lib'].each do |path|
-	Dir[File.join(File.dirname(__FILE__), path)].each {|dir| $:.unshift dir.untaint }
+	Dir[File.join(File.dirname(__FILE__), path)].each {|dir| $:.unshift dir }
 end
 
 require 'cgi'
@@ -30,7 +30,7 @@ require 'tdiary/core_ext'
 # module TDiary
 #
 module TDiary
-	PATH = File::dirname( __FILE__ ).untaint
+	PATH = File::dirname( __FILE__ )
 
 	# tDiary configuration class, initialize tdiary.conf and stored configuration.
 	autoload :Configuration,            'tdiary/configuration'
@@ -126,7 +126,7 @@ module TDiary
 
 		# directory where the server was started
 		def server_root
-			Dir.pwd.untaint
+			Dir.pwd
 		end
 
 		def configuration

--- a/lib/tdiary/admin.rb
+++ b/lib/tdiary/admin.rb
@@ -120,7 +120,7 @@ module TDiary
 		def do_eval_rhtml( prefix )
 			super
 			@plugin.instance_eval { update_proc }
-			anchor_str = @plugin.instance_eval( %Q[anchor "#{@diary.date.strftime('%Y%m%d')}"].untaint )
+			anchor_str = @plugin.instance_eval( %Q[anchor "#{@diary.date.strftime('%Y%m%d')}"] )
 			@io.clear_cache( /(latest|#{@date.strftime( '%Y%m' )})/ )
 			raise ForceRedirect::new( "#{@conf.index}#{anchor_str}" )
 		end

--- a/lib/tdiary/author_only_base.rb
+++ b/lib/tdiary/author_only_base.rb
@@ -86,7 +86,7 @@ EOS
 
 		def load_plugins
 			super
-			@plugin.instance_eval("def csrf_protection\n#{(@csrf_protection.untaint || '').dump}\nend;")
+			@plugin.instance_eval("def csrf_protection\n#{(@csrf_protection || '').dump}\nend;")
 		end
 	end
 

--- a/lib/tdiary/base.rb
+++ b/lib/tdiary/base.rb
@@ -31,7 +31,7 @@ module TDiary
 				if e.class == ForceRedirect
 					raise
 				else
-					body = File.read("#{File.dirname(__FILE__)}/../../views/plugin_error.rhtml").untaint
+					body = File.read("#{File.dirname(__FILE__)}/../../views/plugin_error.rhtml")
 					r = ERB.new(body).result(binding)
 				end
 			end
@@ -62,7 +62,7 @@ module TDiary
 				@io.store_cache( r, prefix ) unless @diaries.empty?
 			end
 
-			r = @plugin.eval_src( r.untaint ) if @plugin
+			r = @plugin.eval_src( r ) if @plugin
 
 			@cookies += @plugin.cookies
 
@@ -123,7 +123,7 @@ module TDiary
 			end.join
 
 			begin
-				r = ERB.new(rhtml.untaint).result(binding)
+				r = ERB.new(rhtml).result(binding)
 			rescue ::Encoding::CompatibilityError
 				# migration error on ruby 1.9 only 1st time, reload.
 				raise ForceRedirect.new(base_url)

--- a/lib/tdiary/cache/file.rb
+++ b/lib/tdiary/cache/file.rb
@@ -28,7 +28,7 @@ module TDiary
 		end
 
 		def delete_data(path)
-			File.delete(path.untaint)
+			File.delete(path)
 		end
 
 		def restore_parser_cache(date, key = nil)

--- a/lib/tdiary/compatible.rb
+++ b/lib/tdiary/compatible.rb
@@ -3,25 +3,6 @@ class CGI
 	ENV = ::ENV.to_hash
 end
 
-# for Ruby 1.9.3
-if ::Object.method_defined?(:untrust)
-	class Object
-		def taint
-			super
-			untrust
-		end
-	end
-end
-
-# for Ruby 1.9.X
-
-# preload transcodes outside $SAFE=4 environment, that is a workaround
-# for the possible SecurityError. see the following uri for the detail.
-# http://redmine.ruby-lang.org/issues/5279
-%w(utf-16be euc-jp iso-2022-jp Shift_JIS).each do |enc|
-	"\uFEFF".encode(enc) rescue nil
-end
-
 # Auto convert ASCII_8BIT pstore data (created by Ruby-1.8) to UTF-8.
 require 'pstore'
 class PStoreRuby18Exception < Exception; end

--- a/lib/tdiary/configuration.rb
+++ b/lib/tdiary/configuration.rb
@@ -111,9 +111,10 @@ module TDiary
 
 			cgi_conf = @io_class.load_cgi_conf(self)
 
-			eval( def_vars1, binding )
+			b = binding
+			eval( def_vars1, b )
 			begin
-				eval( cgi_conf, binding, "(TDiary::Configuration#load_cgi_conf)", 1 )
+				eval( cgi_conf, b, "(TDiary::Configuration#load_cgi_conf)", 1 )
 			rescue SyntaxError
 				enc = case @lang
 						when 'en'
@@ -124,7 +125,7 @@ module TDiary
 				cgi_conf.force_encoding( enc )
 				retry
 			end if cgi_conf
-			eval( def_vars2, binding )
+			eval( def_vars2, b )
 		end
 
 		# loading tdiary.conf in current directory

--- a/lib/tdiary/configuration.rb
+++ b/lib/tdiary/configuration.rb
@@ -16,7 +16,6 @@ module TDiary
 
 		def save
 			result = ERB.new(File.read("#{File.dirname(__FILE__)}/../../views/tdiary.rconf")).result(binding)
-			result
 			eval( result, binding, "(TDiary::Configuration#save)", 1 )
 			@io_class.save_cgi_conf(self, result)
 		end
@@ -111,7 +110,6 @@ module TDiary
 			end
 
 			cgi_conf = @io_class.load_cgi_conf(self)
-			cgi_conf
 
 			eval( def_vars1, binding )
 			begin
@@ -192,7 +190,6 @@ module TDiary
 			else
 				@options2 = {}
 			end
-			@options
 
 			# for 1.4 compatibility
 			@section_anchor = @paragraph_anchor unless @section_anchor

--- a/lib/tdiary/configuration.rb
+++ b/lib/tdiary/configuration.rb
@@ -15,8 +15,8 @@ module TDiary
 		end
 
 		def save
-			result = ERB.new(File.read("#{File.dirname(__FILE__)}/../../views/tdiary.rconf").untaint).result(binding)
-			result.untaint
+			result = ERB.new(File.read("#{File.dirname(__FILE__)}/../../views/tdiary.rconf")).result(binding)
+			result
 			eval( result, binding, "(TDiary::Configuration#save)", 1 )
 			@io_class.save_cgi_conf(self, result)
 		end
@@ -111,7 +111,7 @@ module TDiary
 			end
 
 			cgi_conf = @io_class.load_cgi_conf(self)
-			cgi_conf.untaint
+			cgi_conf
 
 			b = binding.taint
 			eval( def_vars1, b )
@@ -134,12 +134,12 @@ module TDiary
 		def configure_attrs
 			@options = {}
 
-			eval( File::open( 'tdiary.conf' ) {|f| f.read }.untaint, nil, "(tdiary.conf)", 1 )
+			eval( File::open( 'tdiary.conf' ) {|f| f.read }, nil, "(tdiary.conf)", 1 )
 
 			# language setup
 			@lang = 'ja' unless @lang
 			begin
-				instance_eval( File::open( "#{TDiary::PATH}/tdiary/lang/#{@lang}.rb" ){|f| f.read }.untaint, "(tdiary/lang/#{@lang}.rb)", 1 )
+				instance_eval( File::open( "#{TDiary::PATH}/tdiary/lang/#{@lang}.rb" ){|f| f.read }, "(tdiary/lang/#{@lang}.rb)", 1 )
 			rescue Errno::ENOENT
 				@lang = 'ja'
 				retry
@@ -216,7 +216,7 @@ module TDiary
 			else
 				require 'logger'
 				log_path = (@log_path || "#{@data_path}/log")
-				FileUtils.mkdir_p(log_path.untaint)
+				FileUtils.mkdir_p(log_path)
 				TDiary.logger = Logger.new(File.join(log_path, "debug.log"), 'daily')
 				TDiary.logger.level = Logger.const_get(@log_level || 'DEBUG')
 			end

--- a/lib/tdiary/configuration.rb
+++ b/lib/tdiary/configuration.rb
@@ -17,9 +17,7 @@ module TDiary
 		def save
 			result = ERB.new(File.read("#{File.dirname(__FILE__)}/../../views/tdiary.rconf").untaint).result(binding)
 			result.untaint
-			Safe::safe do
-				eval( result, binding, "(TDiary::Configuration#save)", 1 )
-			end
+			eval( result, binding, "(TDiary::Configuration#save)", 1 )
 			@io_class.save_cgi_conf(self, result)
 		end
 
@@ -117,19 +115,17 @@ module TDiary
 
 			b = binding.taint
 			eval( def_vars1, b )
-			Safe::safe do
-				begin
-					eval( cgi_conf, b, "(TDiary::Configuration#load_cgi_conf)", 1 )
-				rescue SyntaxError
-					enc = case @lang
-							when 'en'
-								'UTF-8'
-							else
-								'EUC-JP'
-							end
-					cgi_conf.force_encoding( enc )
-					retry
-				end
+			begin
+				eval( cgi_conf, b, "(TDiary::Configuration#load_cgi_conf)", 1 )
+			rescue SyntaxError
+				enc = case @lang
+						when 'en'
+							'UTF-8'
+						else
+							'EUC-JP'
+						end
+				cgi_conf.force_encoding( enc )
+				retry
 			end if cgi_conf
 			eval( def_vars2, b )
 		end

--- a/lib/tdiary/configuration.rb
+++ b/lib/tdiary/configuration.rb
@@ -113,10 +113,9 @@ module TDiary
 			cgi_conf = @io_class.load_cgi_conf(self)
 			cgi_conf
 
-			b = binding.taint
-			eval( def_vars1, b )
+			eval( def_vars1, binding )
 			begin
-				eval( cgi_conf, b, "(TDiary::Configuration#load_cgi_conf)", 1 )
+				eval( cgi_conf, binding, "(TDiary::Configuration#load_cgi_conf)", 1 )
 			rescue SyntaxError
 				enc = case @lang
 						when 'en'
@@ -127,7 +126,7 @@ module TDiary
 				cgi_conf.force_encoding( enc )
 				retry
 			end if cgi_conf
-			eval( def_vars2, b )
+			eval( def_vars2, binding )
 		end
 
 		# loading tdiary.conf in current directory
@@ -191,9 +190,9 @@ module TDiary
 			if @options2 then
 				@options.update( @options2 )
 			else
-				@options2 = {}.taint
+				@options2 = {}
 			end
-			@options.taint
+			@options
 
 			# for 1.4 compatibility
 			@section_anchor = @paragraph_anchor unless @section_anchor

--- a/lib/tdiary/core_ext.rb
+++ b/lib/tdiary/core_ext.rb
@@ -106,28 +106,6 @@ end
 
 class RackCGI < CGI; end
 
-=begin
-== Safe module
-=end
-module Safe
-	def safe
-		result = nil
-		if $SAFE < 1 then
-			Proc.new {
-				begin
-					$SAFE = 1
-				ensure
-					result = yield
-				end
-			}.call
-		else
-			result = yield
-		end
-		result
-	end
-	module_function :safe
-end
-
 # Local Variables:
 # mode: ruby
 # indent-tabs-mode: t

--- a/lib/tdiary/environment.rb
+++ b/lib/tdiary/environment.rb
@@ -8,7 +8,7 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __FILE__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
 # FIXME: workaround fix for tainted path from Gemfile.local
-$LOAD_PATH.each{|lp| $LOAD_PATH << $LOAD_PATH.shift.dup.untaint}
+$LOAD_PATH.each{|lp| $LOAD_PATH << $LOAD_PATH.shift.dup}
 
 if defined?(Bundler)
   env = [:default, :rack]

--- a/lib/tdiary/io/base.rb
+++ b/lib/tdiary/io/base.rb
@@ -31,7 +31,7 @@ module TDiary
 			end
 
 			def cache_path
-				@_cache_path ||= cache_dir.untaint
+				@_cache_path ||= cache_dir
 				FileUtils.mkdir_p(@_cache_path)
 				@_cache_path
 			end
@@ -41,8 +41,8 @@ module TDiary
 				paths = @tdiary.conf.options['style.path'] ||
 					[TDiary::PATH, TDiary.server_root].map {|base| "#{base}/tdiary/style" }
 				[paths].flatten.uniq.each do |path|
-					path = path.sub(/\/+$/, '').untaint
-					Dir.glob("#{path}/*.rb") {|style_file| require style_file.untaint }
+					path = path.sub(/\/+$/, '')
+					Dir.glob("#{path}/*.rb") {|style_file| require style_file }
 				end
 				TDiary::Style.constants(false).each do |name|
 					prefix = name.slice(/\A(.*)Diary\z/, 1)

--- a/lib/tdiary/io/default.rb
+++ b/lib/tdiary/io/default.rb
@@ -92,7 +92,7 @@ module TDiary
 
 						# convert to referer plugin format
 						diaries.each do |date,diary|
-							fname = file.sub( /\.tdr$/, "#{date[6,2]}.tdr".untaint )
+							fname = file.sub( /\.tdr$/, "#{date[6,2]}.tdr" )
 							File::open( fname, File::WRONLY | File::CREAT ) do |fhr|
 								fhr.flock( File::LOCK_EX )
 								fhr.rewind
@@ -149,12 +149,12 @@ module TDiary
 					conf.data_path += '/' if /\/$/ !~ conf.data_path
 					raise TDiaryError, 'Do not set @data_path as same as tDiary system directory.' if conf.data_path == "#{TDiary::PATH}/"
 
-					File::open( "#{conf.data_path.untaint}tdiary.conf" ){|f| f.read }
+					File::open( "#{conf.data_path}tdiary.conf" ){|f| f.read }
 				rescue IOError, Errno::ENOENT
 				end
 
 				def save_cgi_conf(conf, result)
-					File::open( "#{conf.data_path.untaint}tdiary.conf", 'w' ) {|o| o.print result }
+					File::open( "#{conf.data_path}tdiary.conf", 'w' ) {|o| o.print result }
 				rescue IOError, Errno::ENOENT
 				end
 			end

--- a/lib/tdiary/plugin.rb
+++ b/lib/tdiary/plugin.rb
@@ -92,16 +92,6 @@ module TDiary
 		end
 
 		def eval_src( src )
-			self.taint
-			@conf.taint
-			@title_procs.taint
-			@body_enter_procs.taint
-			@body_leave_procs.taint
-			@section_index.taint
-			@section_enter_procs.taint
-			@comment_leave_procs.taint
-			@subtitle_procs.taint
-			@section_leave_procs.taint
 			ret = eval( src, binding, "(TDiary::Plugin#eval_src)", 1 )
 			@conf.io_class.plugin_close(@storage)
 			return ret

--- a/lib/tdiary/plugin.rb
+++ b/lib/tdiary/plugin.rb
@@ -102,9 +102,7 @@ module TDiary
 			@comment_leave_procs.taint
 			@subtitle_procs.taint
 			@section_leave_procs.taint
-			ret = Safe::safe do
-				eval( src, binding, "(TDiary::Plugin#eval_src)", 1 )
-			end
+			ret = eval( src, binding, "(TDiary::Plugin#eval_src)", 1 )
 			@conf.io_class.plugin_close(@storage)
 			return ret
 		end
@@ -350,12 +348,10 @@ module TDiary
 			r = str.dup
 			if @conf.options['apply_plugin'] and r.index( '<%' ) then
 				r = r.untaint
-				Safe::safe do
-					begin
-						r = ERB::new( r ).result( binding )
-					rescue Exception
-						r = %Q|<p class="message">Invalid Text</p>#{r}|
-					end
+				begin
+					r = ERB::new( r ).result( binding )
+				rescue Exception
+					r = %Q|<p class="message">Invalid Text</p>#{r}|
 				end
 			end
 			r = remove_tag( r ) if remove_tag

--- a/lib/tdiary/plugin.rb
+++ b/lib/tdiary/plugin.rb
@@ -80,14 +80,14 @@ module TDiary
 			@resource_loaded = false
 			begin
 				res_file = File::dirname( file ) + "/#{@conf.lang}/" + File::basename( file )
-				open( res_file.untaint ) do |src|
-					instance_eval( src.read.untaint, "(plugin/#{@conf.lang}/#{File::basename( res_file )})", 1 )
+				open( res_file ) do |src|
+					instance_eval( src.read, "(plugin/#{@conf.lang}/#{File::basename( res_file )})", 1 )
 				end
 				@resource_loaded = true
 			rescue IOError, Errno::ENOENT
 			end
-			File::open( file.untaint ) do |src|
-				instance_eval( src.read.untaint, "(plugin/#{File::basename( file )})", 1 )
+			File::open( file ) do |src|
+				instance_eval( src.read, "(plugin/#{File::basename( file )})", 1 )
 			end
 		end
 
@@ -347,7 +347,6 @@ module TDiary
 			return '' unless str
 			r = str.dup
 			if @conf.options['apply_plugin'] and r.index( '<%' ) then
-				r = r.untaint
 				begin
 					r = ERB::new( r ).result( binding )
 				rescue Exception

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -715,8 +715,7 @@ def comment_mail_send
 	rescue
 		rmail = File::open( "#{TDiary::PATH}/../views/mail.rtxt" ){|f| f.read }
 	end
-	text = @conf.to_mail( ERB::new( rmail.untaint ).result( binding ) )
-	receivers.each(&:untaint)
+	text = @conf.to_mail( ERB::new( rmail ).result( binding ) )
 	comment_mail( text, receivers )
 end
 
@@ -821,7 +820,7 @@ end
 def theme_list_local(list)
 	Dir::glob( theme_paths_local ).sort.map {|dir|
 		theme = dir.sub( %r[.*/theme/], '')
-		next unless FileTest::file?( "#{dir}/#{theme}.css".untaint )
+		next unless FileTest::file?( "#{dir}/#{theme}.css" )
 		name = theme.split( /_/ ).collect{|s| s.capitalize}.join( ' ' )
 		list << ["local/#{theme}",name]
 	}

--- a/lib/tdiary/plugin/50sp.rb
+++ b/lib/tdiary/plugin/50sp.rb
@@ -123,7 +123,7 @@ end
 
 # Finally, we can eval the selected plugins as tdiary.rb does
 if sp_option( 'selected' ) then
-	sp_option( 'selected' ).untaint.split( /\n/ ).collect{ |p| File.basename( p ) }.sort.each do |filename|
+	sp_option( 'selected' ).split( /\n/ ).collect{ |p| File.basename( p ) }.sort.each do |filename|
 		@sp_path.each do |dir|
 			path = "#{dir}/#{filename}"
 			if File.readable?( path ) then

--- a/lib/tdiary/plugin/60sf.rb
+++ b/lib/tdiary/plugin/60sf.rb
@@ -121,7 +121,7 @@ end
 # Finally, we can eval the selected plugins as tdiary.rb does
 if sf_option( 'selected' ) && !@sf_filters then
 	@sf_filters = []
-	sf_option( 'selected' ).untaint.split( /\n/ ).collect{ |p| File.basename( p ) }.sort.each do |filename|
+	sf_option( 'selected' ).split( /\n/ ).collect{ |p| File.basename( p ) }.sort.each do |filename|
 		@sf_path.each do |dir|
 			path = "#{dir}/#{filename}"
 			if File.readable?( path ) then

--- a/lib/tdiary/style.rb
+++ b/lib/tdiary/style.rb
@@ -121,7 +121,7 @@ module TDiary
 			end
 
 			def eval_rhtml( opt, path = "#{File.dirname(__FILE__)}/../.." )
-				ERB.new(File.read("#{path}/views/#{opt['prefix']}diary.rhtml").untaint).result(binding)
+				ERB.new(File.read("#{path}/views/#{opt['prefix']}diary.rhtml")).result(binding)
 			end
 
 			def to_src

--- a/lib/tdiary/style/wiki.rb
+++ b/lib/tdiary/style/wiki.rb
@@ -70,7 +70,7 @@ module TDiary
 			private
 
 			def valid_plugin_syntax?(code)
-				eval( "BEGIN {return true}\n#{code.dup.untaint}", nil, "(plugin)", 0 )
+				eval( "BEGIN {return true}\n#{code.dup}", nil, "(plugin)", 0 )
 			rescue SyntaxError
 				lambda { eval('') }.call
 				false

--- a/lib/tdiary/style/wiki.rb
+++ b/lib/tdiary/style/wiki.rb
@@ -70,13 +70,7 @@ module TDiary
 			private
 
 			def valid_plugin_syntax?(code)
-				lambda {
-					begin
-						$SAFE = 1
-					ensure
-						eval( "BEGIN {return true}\n#{code.dup.untaint}", nil, "(plugin)", 0 )
-					end
-				}.call
+				eval( "BEGIN {return true}\n#{code.dup.untaint}", nil, "(plugin)", 0 )
 			rescue SyntaxError
 				lambda { eval('') }.call
 				false

--- a/lib/tdiary/tasks/server.rake
+++ b/lib/tdiary/tasks/server.rake
@@ -5,7 +5,7 @@
 # You can redistribute it and/or modify it under GPL2 or any later version.
 
 task :server do
-  $:.unshift File.expand_path('../../../', __FILE__).untaint
+  $:.unshift File.expand_path('../../../', __FILE__)
   require 'tdiary'
 
   unless File.exist?(TDiary.root + '/tdiary.conf')

--- a/lib/tdiary/view.rb
+++ b/lib/tdiary/view.rb
@@ -85,7 +85,7 @@ module TDiary
 			@filters = []
 			filter_path = @conf.filter_path || "{#{PATH},#{TDiary.server_root}}/tdiary/filter"
 			Dir::glob( "#{filter_path}/*.rb" ).sort.each do |file|
-				require file.untaint
+				require file
 				@filters << TDiary::Filter::const_get( "#{File::basename( file, '.rb' ).capitalize}Filter" )::new( @cgi, @conf )
 			end
 		end
@@ -225,7 +225,7 @@ module TDiary
 			if @conf.request.xhr?
 				super
 			else
-				anchor_str = @plugin.instance_eval( %Q[anchor "#{@diary.date.strftime('%Y%m%d')}"].untaint )
+				anchor_str = @plugin.instance_eval( %Q[anchor "#{@diary.date.strftime('%Y%m%d')}"] )
 				raise ForceRedirect::new( "#{@conf.index}#{anchor_str}#c#{'%02d' % @diary.count_comments( true )}" )
 			end
 		end

--- a/misc/migrate.rb
+++ b/misc/migrate.rb
@@ -17,7 +17,7 @@ begin
 	else
 		org_path = File::dirname( __FILE__ )
 	end
-	$:.unshift( org_path.untaint )
+	$:.unshift( org_path )
 	require 'tdiary'
 
 	class TDiary::MigrateConfig < TDiary::Config

--- a/misc/plugin/a.rb
+++ b/misc/plugin/a.rb
@@ -147,7 +147,6 @@ def a(key, option_or_name = nil, name = nil, charset = nil)
 
 	if @options["a.tlink"]
 		if defined?(tlink)
-			url.untaint
  			result = tlink(url, value)
 		else
 			result = "tlink is not available."

--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -93,7 +93,7 @@ def amazon_fetch( url, limit = 10 )
 	when Net::HTTPSuccess
 		res.body
 	when Net::HTTPRedirection
-		amazon_fetch( res['location'].untaint, limit - 1 )
+		amazon_fetch( res['location'], limit - 1 )
 	when Net::HTTPForbidden, Net::HTTPServiceUnavailable
 		raise AmazonRedirectError.new( limit.to_s )
 	else
@@ -324,7 +324,7 @@ def amazon_conf_proc
 		@conf['amazon.nodefault'] = (@cgi.params['amazon.nodefault'][0] == 'true')
 		if @cgi.params['amazon.clearcache'][0] == 'true' then
 			Dir["#{@cache_path}/amazon/*"].each do |cache|
-				File::delete( cache.untaint )
+				File::delete( cache )
 			end
 		end
 		unless @conf['amazon.hideconf'] then

--- a/misc/plugin/calendar2.rb
+++ b/misc/plugin/calendar2.rb
@@ -80,10 +80,10 @@ def calender2_make_image(diary, date)
 	image_dir = (@calendar2_imageex_yearlydir == 0 ? @calendar2_image_dir : %Q|#{@calendar2_image_dir}/#{date[0,4]}|)
 	image_url = (@calendar2_imageex_yearlydir == 0 ? @calendar2_image_url : %Q|#{@calendar2_image_url}/#{date[0,4]}|)
 
-	f_list = Dir.glob(%Q|#{image_dir}/#{date}_#{$1}*|.untaint)
+	f_list = Dir.glob(%Q|#{image_dir}/#{date}_#{$1}*|)
 	if f_list[0]
 		file = File.basename(f_list[0])
-		file = %Q|s#{file}| if File.exist?(%Q|#{image_dir}/s#{file}|.untaint)
+		file = %Q|s#{file}| if File.exist?(%Q|#{image_dir}/s#{file}|)
 		%Q|<img src="#{image_url}/#{file}">|
 	else
 		nil

--- a/misc/plugin/category-legacy.rb
+++ b/misc/plugin/category-legacy.rb
@@ -30,7 +30,7 @@ def category_icon_init
 	@conf['category.icon'].split(/\n/).each do |l|
 		c, i = l.split
 		next if c.nil? or i.nil?
-		@category_icon[c] = i if File.exist?("#{@category_icon_dir}#{i}".untaint)
+		@category_icon[c] = i if File.exist?("#{@category_icon_dir}#{i}")
 	end
 end
 category_icon_init
@@ -532,7 +532,7 @@ class Cache
 private
 	def cache_file(category = nil)
 		if category
-			"#{@dir}/#{u( category ).gsub(/%20/,'+')}".untaint
+			"#{@dir}/#{u( category ).gsub(/%20/,'+')}"
 		else
 			"#{@dir}/category_list"
 		end
@@ -551,7 +551,7 @@ private
 		diary.each_section do |s|
 			shorten = begin
 				body = %Q|apply_plugin(#{s.body_to_html.dump}, true)|
-				@conf.shorten(eval(body.untaint, @binding))
+				@conf.shorten(eval(body, @binding))
 			rescue NameError
 				""
 			end
@@ -636,7 +636,7 @@ def category_icon_find_icons
    return if @category_all_icon
 	@category_all_icon = []
 	%w(png jpg gif bmp).each do |e|
-		@category_all_icon += Dir.glob("#{@category_icon_dir}*.#{e}".untaint).map {|i| File.basename(i)}
+		@category_all_icon += Dir.glob("#{@category_icon_dir}*.#{e}").map {|i| File.basename(i)}
 	end
 	@category_all_icon.sort!
 end

--- a/misc/plugin/category.rb
+++ b/misc/plugin/category.rb
@@ -115,7 +115,7 @@ def category_serialize(diary)
 	diary.each_section do |s|
 		shorten = begin
 			body = %Q|apply_plugin(#{s.body_to_html.dump}, true)|
-			@conf.shorten(eval(body.untaint))
+			@conf.shorten(eval(body))
 		rescue NameError
 			""
 		end

--- a/misc/plugin/comment_mail-qmail.rb
+++ b/misc/plugin/comment_mail-qmail.rb
@@ -30,7 +30,7 @@
 def comment_mail( text, to )
 	begin
 		qmail = @conf['comment_mail.qmail'] || '/var/qmail/bin/qmail-inject'
-		open( %Q[|'#{qmail.gsub(/'/, '')}' -f '#{@conf.author_mail.gsub( /'/, '' ).untaint}' '#{to.map{|x|x.gsub(/'/,'')}.join("' '")}'], 'w' ) do |o|
+		open( %Q[|'#{qmail.gsub(/'/, '')}' -f '#{@conf.author_mail.gsub( /'/, '' )}' '#{to.map{|x|x.gsub(/'/,'')}.join("' '")}'], 'w' ) do |o|
 			o.write( text )
 		end
 	rescue

--- a/misc/plugin/counter.rb
+++ b/misc/plugin/counter.rb
@@ -488,10 +488,10 @@ TOPLEVEL_CLASS
 	def kiriban
 		if kiriban?
 			msg = @options["counter.kiriban_msg"] ? @options["counter.kiriban_msg"] : ""
-			ERB.new(msg.untaint).result(binding)
+			ERB.new(msg).result(binding)
 		elsif kiriban_today?
 			msg = @options["counter.kiriban_today_msg"] ? @options["counter.kiriban_today_msg"] : ""
-			ERB.new(msg.untaint).result(binding)
+			ERB.new(msg).result(binding)
 		else
 			@options["counter.kiriban_nomatch_msg"] ? @options["counter.kiriban_nomatch_msg"] : ""
 		end

--- a/misc/plugin/disp_referrer.rb
+++ b/misc/plugin/disp_referrer.rb
@@ -705,7 +705,6 @@ class DispRef2URL
 						break
 					end
 				else
-					name.untaint
 					if title.gsub!( /#{url}/iu ) { eval name } then
 						matched = true
 						break

--- a/misc/plugin/en/disp_referrer.rb
+++ b/misc/plugin/en/disp_referrer.rb
@@ -54,20 +54,20 @@ See ../ChangeLog for changes after this.
 =end
 
 # Message strings
-Disp_referrer2_name = 'Referrer classification'.taint
-Disp_referrer2_abstract = <<'_END'.taint
+Disp_referrer2_name = 'Referrer classification'
+Disp_referrer2_abstract = <<'_END'
 <p>
 	This plugin distinguishes the URLs from antennas and search engines
 	and shows them separately. Search keywords from different engines are
 	compound together.
 </p>
 _END
-Disp_referrer2_cache_info = <<'_END'.taint
+Disp_referrer2_cache_info = <<'_END'
 <p>
 	Total size of the caches is %1$s byte(s).
 </p>
 _END
-Disp_referrer2_update_info = <<'_END'.taint
+Disp_referrer2_update_info = <<'_END'
 <p>
 	Please clear the cache by checking this box:
   <label for="dr2.cache.update"><input id="dr2.cache.update" name="dr2.cache.update" value="force" type="checkbox">clear the cache</label>,
@@ -75,20 +75,20 @@ Disp_referrer2_update_info = <<'_END'.taint
 	after editing the <a href="%1$s">today's link</a> lists.
 </p>
 _END
-Disp_referrer2_move_to_refererlist = <<'_END'.taint
+Disp_referrer2_move_to_refererlist = <<'_END'
 	<a href="%s">Follow this link</a> to edit the referer lists.
 _END
-Disp_referrer2_move_to_config = <<'_END'.taint
+Disp_referrer2_move_to_config = <<'_END'
 	<a href="%s">Follow this link</a> to configure the plug-in.
 _END
-Disp_referrer2_also_todayslink = <<'_END'.taint
+Disp_referrer2_also_todayslink = <<'_END'
 	Referer list can also be edited via &quot;<a href="%s">Today's link</a>&quot;.
 _END
-Disp_referrer2_antenna_label = 'Antennae'.taint
-Disp_referrer2_unknown_label = 'Others'.taint
-Disp_referrer2_search_label = 'Search engines'.taint
-Disp_referrer2_search_unknown_keyword = 'Unknown keyword'.taint
-Disp_referrer2_cache_label = '(cache from %s)'.taint
+Disp_referrer2_antenna_label = 'Antennae'
+Disp_referrer2_unknown_label = 'Others'
+Disp_referrer2_search_label = 'Search engines'
+Disp_referrer2_search_unknown_keyword = 'Unknown keyword'
+Disp_referrer2_cache_label = '(cache from %s)'
 
 class DispRef2SetupIF
 

--- a/misc/plugin/image.rb
+++ b/misc/plugin/image.rb
@@ -71,7 +71,7 @@ def image( id, alt = 'image', thumbnail = nil, size = nil, place = 'photo' )
 			size = %Q| width="#{size.to_i}"|
 		end
 	elsif @image_maxwidth then
-		_, w, _ = image_info( "#{@image_dir}/#{image}".untaint )
+		_, w, _ = image_info( "#{@image_dir}/#{image}" )
 		if w > @image_maxwidth then
 			size = %Q[ width="#{h @image_maxwidth}"]
 		else
@@ -167,7 +167,7 @@ if /^formplugin$/ =~ @mode then
 					rescue NameError
 						size = file.stat.size
 					end
-					output = "#{@image_dir}/#{date}_#{images.length}.#{extension}".untaint
+					output = "#{@image_dir}/#{date}_#{images.length}.#{extension}"
 					File::umask( 022 )
 					File::open( output, "wb" ) do |f|
 						f.print file.read
@@ -176,7 +176,7 @@ if /^formplugin$/ =~ @mode then
 			end
 	   elsif @cgi.params['plugin_image_delimage'][0]
 	      @cgi.params['plugin_image_id'].each do |id|
-	         file = "#{@image_dir}/#{images[id.to_i]}".untaint
+	         file = "#{@image_dir}/#{images[id.to_i]}"
 	         if File::file?( file ) && File::exist?( file )
 	            File::delete( file )
 	         end
@@ -203,7 +203,7 @@ add_form_proc do |date|
 		tmp = ''
 	   images.each_with_index do |img,id|
 			next unless img
-			_, img_w, img_h = image_info(File.join(@image_dir,img).untaint)
+			_, img_w, img_h = image_info(File.join(@image_dir,img))
 			r << %Q[<td><img id="image-index-#{id}" class="image-img form" src="#{h @image_url}/#{h img}" alt="#{id}" width="#{h( (img_w && img_w > 160) ? 160 : (img_w ? img_w : 160) )}"></td>]
 			img_info = ''
 			if img_w && img_h

--- a/misc/plugin/ja/disp_referrer.rb
+++ b/misc/plugin/ja/disp_referrer.rb
@@ -186,20 +186,20 @@ See ../ChangeLog for changes after this.
 =end
 
 # Message strings
-Disp_referrer2_name = 'リンク元もうちょっと強化'.taint
-Disp_referrer2_abstract = <<'_END'.taint
+Disp_referrer2_name = 'リンク元もうちょっと強化'
+Disp_referrer2_abstract = <<'_END'
 <p>
 	アンテナからのリンク、サーチエンジンの検索結果を、
 	通常のリンク元の下にまとめて表示します。
 	サーチエンジンの検索結果は、検索語毎にまとめられます。
 </p>
 _END
-Disp_referrer2_cache_info = <<'_END'.taint
+Disp_referrer2_cache_info = <<'_END'
 <p>
 	現在、キャッシュの大きさは%1$sバイトです。
 </p>
 _END
-Disp_referrer2_update_info = <<'_END'.taint
+Disp_referrer2_update_info = <<'_END'
 <p>
 	「<a href="%1$s">リンク元</a>」の変更の後には、
 	このチェックボックス
@@ -208,20 +208,20 @@ Disp_referrer2_update_info = <<'_END'.taint
 	キャッシュのクリアをしてくさい。
 </p>
 _END
-Disp_referrer2_move_to_refererlist = <<'_END'.taint
+Disp_referrer2_move_to_refererlist = <<'_END'
 	その他のリンク元の置換リストの編集に<a href="%s">移る</a>。
 _END
-Disp_referrer2_move_to_config = <<'_END'.taint
+Disp_referrer2_move_to_config = <<'_END'
 	基本的な設定に<a href="%s">移る</a>。
 _END
-Disp_referrer2_also_todayslink = <<'_END'.taint
+Disp_referrer2_also_todayslink = <<'_END'
 	リンク元置換リストは「<a href="%s">リンク元</a>」からも編集できます。
 _END
-Disp_referrer2_antenna_label = 'アンテナ'.taint
-Disp_referrer2_unknown_label = 'その他のリンク元'.taint
-Disp_referrer2_search_label = '検索'.taint
-Disp_referrer2_search_unknown_keyword = 'キーワード不明'.taint
-Disp_referrer2_cache_label = '(%sのキャッシュ)'.taint
+Disp_referrer2_antenna_label = 'アンテナ'
+Disp_referrer2_unknown_label = 'その他のリンク元'
+Disp_referrer2_search_label = '検索'
+Disp_referrer2_search_unknown_keyword = 'キーワード不明'
+Disp_referrer2_cache_label = '(%sのキャッシュ)'
 
 class DispRef2SetupIF
 

--- a/misc/plugin/my-sequel.rb
+++ b/misc/plugin/my-sequel.rb
@@ -206,7 +206,7 @@ _END
 		unless hash.has_key?(key)
 			hash[key] = Array.new
 			begin
-				hash[key].taint
+				hash[key]
 			rescue SecurityError
 			end
 		end
@@ -215,10 +215,10 @@ _END
 	end
 
 	def initialize(cache_path)
-		@link_srcs = Hash.new.taint	# key:dst anchor value:Array of src anchors
-		@current_dsts = Hash.new.taint	# key:src anchor value:Array of dst anchors
-		@cached_dsts = Hash.new.taint	# for restore_dsts and clean_srcs
-		@vanished_dsts = Hash.new.taint	# key:src date value:Array of dst anchors
+		@link_srcs = Hash.new	# key:dst anchor value:Array of src anchors
+		@current_dsts = Hash.new	# key:src anchor value:Array of dst anchors
+		@cached_dsts = Hash.new	# for restore_dsts and clean_srcs
+		@vanished_dsts = Hash.new	# key:src date value:Array of dst anchors
 		@cache_path = cache_path
 	end
 
@@ -256,7 +256,7 @@ _END
 			next unless MySequel.date(src_anchor) == datestr
 			@current_dsts[src_anchor] = Array.new
 			begin
-				@current_dsts[src_anchor].taint
+				@current_dsts[src_anchor]
 			rescue SecurityError
 			end
 		end
@@ -311,9 +311,9 @@ _END
 			unless @srcs_loaded[cache_key] then
 				each_cached(cache_key, 'src') do |anchor, array|
 					unless @link_srcs.has_key?(anchor)
-						@link_srcs[anchor] = array.taint
+						@link_srcs[anchor] = array
 					else
-						@link_srcs[anchor] += array.taint
+						@link_srcs[anchor] += array
 					end
 				end
 				@srcs_loaded[cache_key] = true
@@ -327,7 +327,6 @@ _END
 		MySequel.each_cache_key(dates) do |cache_key|
 			unless @dsts_loaded[cache_key] then
 				each_cached(cache_key, 'dst') do |anchor, array|
-					array.taint
 					@cached_dsts[anchor] = array
 					@current_dsts[anchor] = array.dup
 				end
@@ -387,7 +386,7 @@ _END
 
 		store(hash_for_cache(@link_srcs, 'src'))
 		store(hash_for_cache(@current_dsts, 'dst'))
-		@vanished_dsts = Hash.new.taint
+		@vanished_dsts = Hash.new
 	end
 
 end

--- a/misc/plugin/ping.rb
+++ b/misc/plugin/ping.rb
@@ -36,7 +36,7 @@ def ping( list )
 	require 'timeout'
 	threads = []
 	list.each do |url|
-		u = URI::parse( url.untaint )
+		u = URI::parse( url )
 		next unless u.host
 		threads << Thread.start( u, xml ) do |u, xml|
 			begin

--- a/misc/plugin/recent_comment3.rb
+++ b/misc/plugin/recent_comment3.rb
@@ -42,7 +42,7 @@ def recent_comment3(ob_max = 'OBSOLUTE' ,sep = 'OBSOLUTE',ob_date_format = 'OBSO
 	migrate_old_data
 	recent_comment3_init
 
-	cache = @conf['recent_comment3.cache'].untaint
+	cache = @conf['recent_comment3.cache']
 	date_format = @conf['recent_comment3.date_format']
 	excepts = @conf['recent_comment3.except_list'].split(/,/)
 	format = @conf['recent_comment3.format']
@@ -129,7 +129,7 @@ add_update_proc do
 	recent_comment3_init
 
 	date = @date.strftime( '%Y%m%d' )
-	cache = @conf['recent_comment3.cache'].untaint
+	cache = @conf['recent_comment3.cache']
 	size = @conf['recent_comment3.cache_size']
 
 	if @mode == 'comment' && @comment && @comment.visible?

--- a/misc/plugin/recent_rss.rb
+++ b/misc/plugin/recent_rss.rb
@@ -28,8 +28,6 @@ RECENT_RSS_HTTP_HEADER = {
 }
 
 def recent_rss( url, max = 5, cache_time = 3600, show_modified = true )
-	url.untaint
-
 	cache_file = "#{@cache_path}/recent_rss.#{CGI.escape(url)}"
 
 	recent_rss_cache_rss(url, cache_file, cache_time.to_i)
@@ -103,7 +101,7 @@ def recent_rss_cache_rss(url, cache_file, cache_time)
 			raise InvalidResourceError if rss_source.nil?
 
 			# parse RSS
-			rss = ::RSS::Parser.parse(rss_source.untaint, false)
+			rss = ::RSS::Parser.parse(rss_source, false)
 			raise ::RSS::Error if rss.nil?
 
 			# pre processing

--- a/misc/plugin/search-default.rb
+++ b/misc/plugin/search-default.rb
@@ -72,7 +72,7 @@ module DefaultIOSearch
 
 	def foreach_data_file(data_path, &block)
 		Dir.glob("#{data_path}/[0-9]*/*.td2").sort.reverse_each do |path|
-			yield path.untaint
+			yield path
 		end
 	end
 
@@ -146,7 +146,7 @@ module DefaultIOSearch
 			raise "unkwnown format: #{ver}" unless ver == 'TDIARY2.00.00' or ver == 'TDIARY2.01.00'
 			f.each('') do |header|
 				h = {}
-				header.untaint.strip.each_line do |line|
+				header.strip.each_line do |line|
 					begin
 						n, v = *line.split(':', 2)
 					rescue ArgumentError
@@ -154,7 +154,7 @@ module DefaultIOSearch
 					end
 					h[n.strip] = v.strip
 				end
-				body = f.gets("\n.\n").chomp(".\n").untaint
+				body = f.gets("\n.\n").chomp(".\n")
 				yield h, body
 			end
 		}

--- a/misc/plugin/weather.rb
+++ b/misc/plugin/weather.rb
@@ -297,7 +297,7 @@ class Weather
 			when Net::HTTPSuccess
 				res.body
 			when Net::HTTPRedirection
-				fetch( res['location'].untaint, limit - 1 )
+				fetch( res['location'], limit - 1 )
 			else
 				raise ArgumentError, res.error!
 			end

--- a/misc/plugin/whatsnew.rb
+++ b/misc/plugin/whatsnew.rb
@@ -32,7 +32,7 @@
 # Distributed under the GPL2 or any later version.
 #
 
-@whats_new = {}.taint
+@whats_new = {}
 
 def whats_new
 	return apply_plugin( @whats_new[:read_mark] ) unless @cgi

--- a/misc/plugin/xmlrpc/xmlrpc.rb
+++ b/misc/plugin/xmlrpc/xmlrpc.rb
@@ -12,7 +12,7 @@ if FileTest::symlink?( __FILE__ ) then
 else
   org_path = File::dirname( __FILE__ )
 end
-$:.unshift org_path.untaint
+$:.unshift org_path
 require 'tdiary'
 require 'uri'
 

--- a/spec/plugin/plugin_helper.rb
+++ b/spec/plugin/plugin_helper.rb
@@ -1,4 +1,4 @@
-$:.unshift File.expand_path(File.join(File.dirname(__FILE__), '../../misc/plugin')).untaint
+$:.unshift File.expand_path(File.join(File.dirname(__FILE__), '../../misc/plugin'))
 
 require File.dirname(__FILE__) + "/../spec_helper"
 require 'erb'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$:.unshift File.expand_path(File.join(File.dirname(__FILE__), '..')).untaint
+$:.unshift File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
 ENV['RACK_ENV'] = "test"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 ['..', '../misc/plugin'].each do |path|
-  $LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), path)).untaint
+  $LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), path))
 end
 
 require 'tdiary/environment'

--- a/update.fcgi
+++ b/update.fcgi
@@ -9,12 +9,12 @@
 #
 require 'fcgi'
 # workaround untaint LOAD_PATH for rubygems library path is always tainted.
-$:.each{|path| path.untaint if path.include?('fcgi') && path.tainted? }
+$:.each{|path| path if path.include?('fcgi') && path.tainted? }
 
 if FileTest::symlink?( __FILE__ ) then
-	org_path = File::dirname( File::readlink( __FILE__ ) ).untaint
+	org_path = File::dirname( File::readlink( __FILE__ ) )
 else
-	org_path = File::dirname( __FILE__ ).untaint
+	org_path = File::dirname( __FILE__ )
 end
 load "#{org_path}/misc/lib/fcgi_patch.rb"
 

--- a/update.fcgi
+++ b/update.fcgi
@@ -9,7 +9,7 @@
 #
 require 'fcgi'
 # workaround untaint LOAD_PATH for rubygems library path is always tainted.
-$:.each{|path| path if path.include?('fcgi') && path.tainted? }
+$:.each{|path| path if path.include?('fcgi') }
 
 if FileTest::symlink?( __FILE__ ) then
 	org_path = File::dirname( File::readlink( __FILE__ ) )

--- a/update.rb
+++ b/update.rb
@@ -14,7 +14,7 @@ begin
 	else
 		org_path = File::dirname( __FILE__ )
 	end
-	$:.unshift( (org_path + '/lib').untaint ) unless $:.include?( org_path + '/lib' )
+	$:.unshift( (org_path + '/lib') ) unless $:.include?( org_path + '/lib' )
 	require 'tdiary'
 
 	encoding_error = {}


### PR DESCRIPTION
Ruby 2.6 will be modified scope of SAFE level.

https://github.com/ruby/ruby/commit/c39bdb798d838d58126b548465908243c41bb1fb

It breaks Thread local usage of SAFE level. So, We gave up to support SAFE mechanism in core module of tDiary.

Fixes https://github.com/tdiary/tdiary-core/issues/661
