### PR TITLE
remove support of ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 services: memcache
 
 rvm:
-  - 2.2.9
   - 2.3.6
   - 2.4.3
   - 2.5.0

--- a/lib/tdiary/tasks/release.rake
+++ b/lib/tdiary/tasks/release.rake
@@ -50,7 +50,7 @@ begin
 				end
 
 				Dir.chdir '.bundle/ruby' do
-					versions = %w(2.2.0 2.3.0 2.4.0 2.5.0)
+					versions = %w(2.3.0 2.4.0 2.5.0)
 					current = `ls`.chomp
 					versions.each {|version|
 						FileUtils.cp_r current, version unless current == version


### PR DESCRIPTION
今月末でサポート終了するruby 2.2をパッケージとCIから外した。