### PR TITLE
Remove sprockets, assets pipeline is obsoleted in 2018

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,6 @@ gem 'emot'
 gem 'mail'
 gem 'rake'
 
-group :rack do
-  gem 'sprockets'
-end
-
 group :development do
   gem 'pit', require: false
   gem 'racksh', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,6 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
-    concurrent-ruby (1.1.4)
     coveralls (0.8.22)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -103,9 +102,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sprockets (3.7.2)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
     sqlite3 (1.4.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
@@ -142,7 +138,6 @@ DEPENDENCIES
   selenium-webdriver
   sequel
   simplecov
-  sprockets
   sqlite3
   test-unit
 

--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -27,7 +27,7 @@ module TDiary
 				map base_dir do
 					map '/' do
 						use TDiary::Rack::HtmlAnchor
-						use TDiary::Rack::Static, "public"
+						use TDiary::Rack::Static, ["public"]
 						use TDiary::Rack::ValidRequestPath
 						map index_path do
 							run TDiary::Dispatcher.index
@@ -40,8 +40,7 @@ module TDiary
 					end
 
 					map assets_path do
-						use TDiary::Rack::Static, "js"
-						use TDiary::Rack::Static, "theme"
+						use TDiary::Rack::Static, ["js", "theme"]
 					end
 				end
 			end

--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -18,6 +18,8 @@ module TDiary
 		def initialize( base_dir = nil )
 			index_path   = self.index_path
 			update_path  = self.update_path
+			assets_path  = self.assets_path
+			assets_paths = self.assets_paths
 
 			base_dir ||= self.base_dir
 
@@ -35,6 +37,11 @@ module TDiary
 					map update_path do
 						use TDiary::Rack::Auth
 						run TDiary::Dispatcher.update
+					end
+
+					map assets_path do
+						use TDiary::Rack::Static, "js"
+						use TDiary::Rack::Static, "theme"
 					end
 				end
 			end
@@ -64,6 +71,10 @@ module TDiary
 
 		def update_path
 			(Pathname.new('/') + URI(TDiary.configuration.update).path).to_s
+		end
+
+		def assets_path
+			'/assets'
 		end
 
 		def base_dir

--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -18,8 +18,6 @@ module TDiary
 		def initialize( base_dir = nil )
 			index_path   = self.index_path
 			update_path  = self.update_path
-			assets_path  = self.assets_path
-			assets_paths = self.assets_paths
 
 			base_dir ||= self.base_dir
 
@@ -37,15 +35,6 @@ module TDiary
 					map update_path do
 						use TDiary::Rack::Auth
 						run TDiary::Dispatcher.update
-					end
-
-					map assets_path do
-						environment = Sprockets::Environment.new
-						assets_paths.each {|assets_path|
-							environment.append_path assets_path
-						}
-
-						run environment
 					end
 				end
 			end
@@ -75,10 +64,6 @@ module TDiary
 
 		def update_path
 			(Pathname.new('/') + URI(TDiary.configuration.update).path).to_s
-		end
-
-		def assets_path
-			'/assets'
 		end
 
 		def base_dir

--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -40,7 +40,7 @@ module TDiary
 					end
 
 					map assets_path do
-						use TDiary::Rack::Static, ["js", "theme"]
+						run TDiary::Rack::Static.new(nil, ["js", "theme"])
 					end
 				end
 			end

--- a/lib/tdiary/rack/static.rb
+++ b/lib/tdiary/rack/static.rb
@@ -5,11 +5,17 @@ module TDiary
 		class Static
 			def initialize( app, base_dir )
 				@app = app
-				@file = ::Rack::File.new( base_dir )
+				@file = base_dir.map{|dir| ::Rack::File.new(dir) }
 			end
 
 			def call( env )
-				result = @file.call( env )
+				result = []
+
+				@file.each do |f|
+					result = f.call(env)
+					break if result[0].to_i < 400 || result[0].to_i >= 500
+				end
+
 				if result[0].to_i >= 400 && result[0].to_i < 500
 					@app.call( env )
 				else

--- a/misc/paas/heroku/Gemfile.lock
+++ b/misc/paas/heroku/Gemfile.lock
@@ -227,7 +227,6 @@ DEPENDENCIES
   selenium-webdriver
   sequel
   simplecov
-  sprockets
   sqlite3
   tdiary-contrib!
   tdiary-io-mongodb!

--- a/spec/core/rack/static_spec.rb
+++ b/spec/core/rack/static_spec.rb
@@ -7,7 +7,7 @@ describe TDiary::Rack::Static do
 
 	describe "reserve static files" do
 		let(:app) { TDiary::Rack::Static.new(
-			lambda{|env| [500, {}, ['Internal Server Error']]}, 'doc')}
+			lambda{|env| [500, {}, ['Internal Server Error']]}, ['doc'])}
 
 		it 'should return the file in static directory' do
 			get '/README.md'
@@ -23,5 +23,21 @@ describe TDiary::Rack::Static do
 			post '/index.rb'
 			expect(last_response.status).to be 500
 		end
+	end
+
+	describe "resurve mutiple static files" do
+		let(:app) { TDiary::Rack::Static.new(
+			lambda{|env| [500, {}, ['Internal Server Error']]}, ['js', 'theme'])}
+
+		it 'should return the file in js directory' do
+			get '/00default.js'
+			expect(last_response).to be_ok
+		end
+
+		it 'should return the file in theme directory' do
+			get '/base.css'
+			expect(last_response).to be_ok
+		end
+
 	end
 end

--- a/tdiary.gemspec
+++ b/tdiary.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mail'
   spec.add_dependency 'rack'
   spec.add_dependency 'rake'
-  spec.add_dependency 'sprockets'
   spec.add_dependency 'thor'
   spec.add_dependency "bundler", ">= 1.3", "< 3.0"
 end


### PR DESCRIPTION
遥か昔に CoffeeScript や sass などを自動でコンパイルして、rack で透過的に扱えれば便利だろうと入れた sprockets ですが時はたち、babel で transpile して、webpack などで bundle したものを配布する世の中になってしまいました。

tDiary でも実際には `rake assets:copy` タスクなどで `public/assets` にまるっとコピーして tar.gz を配布しているのであまり活用されていません。というわけで依存関係から消してしまおうと思います。

`assets:copy` をよっしゃここで webpack だ〜と行ければ良かったのですが、今の javascript/css だと一気にジャンプするのは無理そうでした。それは次のフェーズでやります。

TODO: 配布パッケージなどの先までもう少し精査していきます。