### PR TITLE
fix converting img to amp-img tags when parametes have '>' chars

### DIFF
--- a/misc/plugin/amp.rb
+++ b/misc/plugin/amp.rb
@@ -55,7 +55,7 @@ end
 
 def amp_body(diary)
   apply_plugin(diary.to_html)
-    .gsub(/<img\s([^>]+)>/, '<amp-img \1 layout="responsive">')
+    .gsub(/<img\s/, '<amp-img layout="responsive" ')
     .gsub(/<script[^<]+<\/script>/, '')
 end
 

--- a/spec/plugin/amp_spec.rb
+++ b/spec/plugin/amp_spec.rb
@@ -79,7 +79,7 @@ describe "amp plugin w/" do
 				HTML
 			} }
 			it { expect(subject).to include('<h3>subsection</h3>') }
-			it { expect(subject).to include('<amp-img src="image.jpg" weight="640" height="480" layout="responsive">') }
+			it { expect(subject).to include('<amp-img layout="responsive" src="image.jpg" weight="640" height="480">') }
 		end
 
 		describe "when contain script element" do


### PR DESCRIPTION
img要素のパラメタが「>」を含んでいる場合、amp-img要素への変換が失敗するので修正。本来は「>」は日記記述者がエスケープすべきだが、いちおうこれでフォローできる。