### PR TITLE
improve dropdown_calendar plugin

### DIFF
--- a/misc/paas/heroku/tdiary.conf
+++ b/misc/paas/heroku/tdiary.conf
@@ -27,7 +27,8 @@ require 'tempfile'
 @options['sp.path'] = ['misc/plugin']
 @options['sp.selected'] = %w(amazon.rb append-css.rb calendar2.rb comment_ajax.rb comment_mail-smtp.rb dropdown_calendar.rb footnote.rb highlight.rb html_anchor.rb jdate.rb makerss.rb kw.rb my-ex.rb select-style.rb theme_online.rb ).join("\n")
 
-@options['dropdown_calendar.label'] = ''
+# dropdown_calendarの先頭に表示するテキスト
+# @options['dropdown_calendar.label'] = '過去の日記'
 
 @options['comment_mail.smtp_host'] = 'smtp.sendgrid.net'
 @options['comment_mail.smtp_port'] = 587

--- a/misc/plugin/dropdown_calendar.rb
+++ b/misc/plugin/dropdown_calendar.rb
@@ -11,15 +11,16 @@
 
 def calendar
 	result = %Q[<form method="get" action="#{h @index}">\n]
-	result << %Q[<div class="calendar">#{@conf.options['dropdown_calendar.label'] || @dropdown_calendar_label}\n]
-	result << %Q[<select name="date">\n]
+	result << %Q[<div class="calendar">\n]
+	result << %Q[<select name="url" onChange="window.location=$(this).val()">\n]
+	result << "<option value=''>#{@conf.options['dropdown_calendar.label'] || @dropdown_calendar_label}</option>\n"
 	@years.keys.sort.reverse_each do |year|
 		@years[year.to_s].sort.reverse_each do |month|
-			result << %Q[<option value="#{year}#{month}">#{year}-#{month}</option>\n]
+			date = "#{year}#{month}"
+			result << %Q[<option value="#{h @index}#{anchor(date)}">#{year}-#{month}</option>\n]
 		end
 	end
 	result << "</select>\n"
-	result << %Q[<input type="submit" value="Go">\n]
 	result << "</div>\n</form>"
 end
 

--- a/spec/fixtures/tdiary.conf.gem
+++ b/spec/fixtures/tdiary.conf.gem
@@ -37,7 +37,7 @@ recent_comment3.rb
 recent_list.rb
 "
 
-@options['dropdown_calendar.label'] = ''
+@options['dropdown_calendar.label'] = '過去の日記'
 @options['makerss.file'] = 'index.rdf'
 @options['makerss.no_comments.file'] = 'no_comments.rdf'
 

--- a/spec/fixtures/tdiary.conf.rack
+++ b/spec/fixtures/tdiary.conf.rack
@@ -37,7 +37,7 @@ recent_comment3.rb
 recent_list.rb
 "
 
-@options['dropdown_calendar.label'] = ''
+@options['dropdown_calendar.label'] = '過去の日記'
 @options['makerss.file'] = 'index.rdf'
 @options['makerss.no_comments.file'] = 'no_comments.rdf'
 

--- a/spec/fixtures/tdiary.conf.webrick
+++ b/spec/fixtures/tdiary.conf.webrick
@@ -38,7 +38,7 @@ recent_comment3.rb
 recent_list.rb
 "
 
-@options['dropdown_calendar.label'] = ''
+@options['dropdown_calendar.label'] = '過去の日記'
 @options['makerss.file'] = 'index.rdf'
 @options['makerss.no_comments.file'] = 'no_comments.rdf'
 

--- a/tdiary.conf.beginner
+++ b/tdiary.conf.beginner
@@ -67,7 +67,8 @@ recent_comment3.rb
 recent_list.rb
 "
 
-@options['dropdown_calendar.label'] = ''
+# dropdown_calendarの先頭に表示するテキスト
+# @options['dropdown_calendar.label'] = '過去の日記'
 
 @options['spamfilter.bad_comment_patts'] = "(href=|casino|gambling|betting|fastsearch\\.eu\\.com|ganzao|poker|holdem|hold.em|roulette|drug|tramadol|viagra|fioricet|oxycontin|biaxin|aldara|business cards|home depot|slot.?machine|insurance|getblog2|video-game|Good site|internet-all\\.com|deai|tdfms|comu2|omaha)\r\n"
 @options['spamfilter.bad_ip_addrs'] = ""


### PR DESCRIPTION
dropdown_calendarが生成するURLは長らくanchor()が生成するそれと異なっていたが、これを合わせるために以下の変更を行った。

* inline JavaScriptを使って、リストから選択するだけでanchor()が生成したURLに直接ジャンプする
* 指定したラベルはリストの最上部に挿入(↑の実装のため最上部のアイテムが選択できない故)