### PR TITLE
amazon.rb: catch Net::HTTPExceptions and log the reason

### DIFF
--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -125,7 +125,8 @@ def amazon_call_ecs( asin, id_type, country )
 	rescue AmazonRedirectError
 		limit = $!.message.to_i
 		retry
-	rescue ArgumentError, SystemCallError
+	rescue ArgumentError, SystemCallError, Net::HTTPExceptions
+		@logger.error "amazon.rb: #{$!.message} by #{asin}"
 	end
 end
 


### PR DESCRIPTION
amazon auth proxyがエラーを返してきたときなどに`Net::HTTPExceptions`が発生するのを捕まえていなかったため、日記がエラーメッセージのみになる場合があった。この修正でエラーそのものは解消されないが、amazon.rbの出力はASINのみになって他の文章に影響はなくなる。