### PR TITLE
Improve Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .bundle
+.htpasswd
 vendor/bundle
 public/assets/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,13 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY [ "Gemfile", "Gemfile.lock", "/usr/src/app/" ]
-RUN bundle --path=vendor/bundle --without=development:test --jobs=4 --retry=3
+RUN apt update && apt install libidn11-dev; \
+    echo 'gem "puma" \n\
+    gem "tdiary-contrib" \n\
+    gem "tdiary-style-gfm" \n\
+    gem "tdiary-style-rd" \n'\
+    > Gemfile.local; \
+    bundle --path=vendor/bundle --without=development:test --jobs=4 --retry=3
 
 COPY . /usr/src/app/
 RUN if [ ! -e tdiary.conf ]; then cp tdiary.conf.beginner tdiary.conf; fi && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ RUN if [ ! -e tdiary.conf ]; then cp tdiary.conf.beginner tdiary.conf; fi && \
 
 VOLUME [ "/usr/src/app/data", "/usr/src/app/public" ]
 EXPOSE 9292
+ENV HTPASSWD=data/.htpasswd
 CMD [ "bundle", "exec", "rackup", "-o", "0.0.0.0", "-p", "9292" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3
+FROM ruby:2.5
 MAINTAINER MATSUOKA Kohei @machu
 
 RUN mkdir -p /usr/src/app

--- a/lib/tdiary/cli.rb
+++ b/lib/tdiary/cli.rb
@@ -148,7 +148,7 @@ module TDiary
 			if password != password2
 				raise StandardError, 'password verification error'
 			end
-			htpasswd = WEBrick::HTTPAuth::Htpasswd.new('.htpasswd')
+			htpasswd = WEBrick::HTTPAuth::Htpasswd.new(ENV['HTPASSWD'] || '.htpasswd')
 			htpasswd.set_passwd(nil, username, password)
 			htpasswd.flush
 		end

--- a/lib/tdiary/rack/auth.rb
+++ b/lib/tdiary/rack/auth.rb
@@ -8,7 +8,7 @@ module TDiary
 				if defined? ::OmniAuth
 					@app = TDiary::Rack::Auth::OmniAuth.new(app)
 				else
-					@app = TDiary::Rack::Auth::Basic.new(app, '.htpasswd')
+					@app = TDiary::Rack::Auth::Basic.new(app, ENV['HTPASSWD'] || '.htpasswd')
 				end
 			end
 


### PR DESCRIPTION
Dockerfileを改善して実用性を高める。

* ベースをruby:2.5に変更
* 環境変数`HTPASSWD`がある場合はそのファイルを使ってBASIC認証する
* Dockerfile内でENVに`HTPASSWD`として`data/.htpasswd`を指定
* .dockerignoreに`.htpasswd`を追加
* Dockerfile内でGemfile.localを生成してcontribおよびstyle-gfm、style-rd、puma gemを追加