### PR TITLE
fix #698 warning in tarball  made by macos

### DIFF
--- a/lib/tdiary/tasks/release.rake
+++ b/lib/tdiary/tasks/release.rake
@@ -64,7 +64,7 @@ begin
 		end
 
 		mv repo, dest
-		sh "tar zcf #{dest}.tar.gz #{dest}"
+		sh "tar --format=ustar zcf #{dest}.tar.gz #{dest}"
 		mv dest, repo
 		TARBALLS << "#{dest}.tar.gz"
 	end
@@ -80,7 +80,7 @@ begin
 				mv d, "tdiary-core/theme/" rescue true
 			end
 			mv "tdiary-core", "tdiary#{suffix}"
-			sh "tar zcf tdiary-full#{suffix}.tar.gz tdiary#{suffix}"
+			sh "tar --format=ustar zcf tdiary-full#{suffix}.tar.gz tdiary#{suffix}"
 			TARBALLS << "tdiary-full#{suffix}.tar.gz"
 			rm_rf "tdiary#{suffix}"
 			REPOS.each {|repo| rm_rf repo rescue true }


### PR DESCRIPTION
BSD版tar (MacOS)で作られたパッケージをGNU版tarで展開するときにwarningが出る問題をなくす。 see comments of #698