### PR TITLE
fix #751: replace amazon default images in tdiary.github.io

### DIFF
--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -166,7 +166,7 @@ def amazon_image( item )
 		image[:height] = item.nodes("#{node_prefix}/Height")[0].text
 		image[:width] = item.nodes("#{node_prefix}/Width")[0].text
 	rescue
-		base = @conf['amazon.default_image_base'] || 'http://www.tdiary.org/images/amazondefaults/'
+		base = @conf['amazon.default_image_base'] || 'http://tdiary.github.io/tdiary-theme/plugin/amazon/'
 		case @conf['amazon.imgsize']
 		when 0
 			image[:src] = "#{base}large.png"


### PR DESCRIPTION
Amazon書影のデフォルト画像がhttpで配布されていたので、tdiary.github.io上に展開してそちらを指すように変更。