### PR TITLE
stop support ruby 2.3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ sudo: false
 services: memcache
 
 rvm:
-  - 2.3.8
   - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.5.4
+  - 2.6.2
   - ruby-head
 
 matrix:

--- a/lib/tdiary/tasks/release.rake
+++ b/lib/tdiary/tasks/release.rake
@@ -50,7 +50,7 @@ begin
 				end
 
 				Dir.chdir '.bundle/ruby' do
-					versions = %w(2.3.0 2.4.0 2.5.0 2.6.0)
+					versions = %w(2.4.0 2.5.0 2.6.0)
 					current = `ls`.chomp
 					versions.each {|version|
 						FileUtils.cp_r current, version unless current == version


### PR DESCRIPTION
今月末に控えているruby 2.3系のEOLを先取り