### PR TITLE
support extentions (cf.tdiary-contrib) assets paths again

### DIFF
--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -40,7 +40,7 @@ module TDiary
 					end
 
 					map assets_path do
-						run TDiary::Rack::Static.new(nil, ["js", "theme"])
+						run TDiary::Rack::Static.new(nil, assets_paths)
 					end
 				end
 			end


### PR DESCRIPTION
* degraged by #674
* use tDiary#assets_paths for static paths