### PR TITLE
update PhantomJS for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,8 @@ bundler_args: "--without server --jobs=3 --retry=3"
 
 before_install:
   - "echo 'gemspec' > Gemfile.local"
-  - echo "gem 'phantomjs', '= 1.9.8.0'" >> Gemfile.local
   - gem update --system
   - gem update bundler
-  - bundle update phantomjs
 
 before_script:
   - npm install

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/tdiary/tdiary-core",
   "devDependencies": {
-    "jquery": "~3.4.1",
+    "jquery": "~3.2.1",
     "jasmine-jquery": "~2.1.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/tdiary/tdiary-core",
   "devDependencies": {
     "jquery": "~3.4.1",
-    "jasmine-jquery": "~2.0.3"
+    "jasmine-jquery": "~2.1.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/tdiary/tdiary-core",
   "devDependencies": {
-    "jquery": "~3.2.1",
+    "jquery": "~3.4.1",
     "jasmine-jquery": "~2.1.1"
     }
 }


### PR DESCRIPTION
jQueryのアップデート(3.4.1)にともない、Travisでjasmine:ciがエラーになるようになったので、Travis上でのみPhantomJSをダウングレードしていた指定を削除した。また同時にjasmine-jqueryを最新版へ。