### PR TITLE
use PORT environment in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,6 @@ RUN if [ ! -e tdiary.conf ]; then cp tdiary.conf.beginner tdiary.conf; fi && \
 
 VOLUME [ "/usr/src/app/data", "/usr/src/app/public" ]
 EXPOSE 9292
+ENV PORT=9292
 ENV HTPASSWD=data/.htpasswd
-CMD [ "bundle", "exec", "rackup", "-o", "0.0.0.0", "-p", "9292" ]
+CMD bundle exec rackup -o 0.0.0.0 -p ${PORT}


### PR DESCRIPTION
外部から環境変数PORTで使用するポートを指定してくるクラウドサービス(Google Cloud Runなど)を想定して、Dockerfile内で環境変数を使うように修正。環境変数を展開するためにCMDをシェル形式に変更した。