### PR TITLE
amazon plugin: support HTTP Found response and discard wrong stored cache

### DIFF
--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -92,7 +92,7 @@ def amazon_fetch( url, limit = 10 )
 	case res
 	when Net::HTTPSuccess
 		res.body
-	when Net::HTTPRedirection
+	when Net::HTTPRedirection, Net::HTTPFound
 		amazon_fetch( res['location'], limit - 1 )
 	when Net::HTTPForbidden, Net::HTTPServiceUnavailable
 		raise AmazonRedirectError.new( limit.to_s )
@@ -281,6 +281,9 @@ def amazon_get( asin, with_image = true, label = nil, pos = 'amazon' )
 		Dir::mkdir( cache ) unless File::directory?( cache )
 		begin
 			xml = File::read( "#{cache}/#{country}#{asin}.xml" )
+			if xml.chomp == 'true'
+				raise Errno::ENOENT
+			end
 		rescue Errno::ENOENT
 			xml = amazon_call_ecs( asin, id_type, country )
 			File::open( "#{cache}/#{country}#{asin}.xml", 'wb' ) {|f| f.write( xml )}


### PR DESCRIPTION
amazonプラグインにて

```
undefined method `has_item?' for nil:NilClass (NoMethodError)

(plugin/amazon.rb):305:in `rescue in amazon_get'
(plugin/amazon.rb):279:in `amazon_get'
(plugin/amazon.rb):387:in `isbn_image'
```

というエラーが出るため調べたところ、XMLであるはずのキャッシュが `true` という文字列のみになっていました。

HTTP Redirection 以外に HTTP Found でもリダイレクトしていたためそれを追加、また既に間違って `true` をキャッシュしていた場合は取得し直すようにしました。