### PR TITLE
sort comments by date on a new comment added

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-08-17  Tada, Tadashi <t@tdtds.jp>
+	* sort commants by date on a new comment added
+
 2019-08-15  HIGUCHI Daisuke (VDR dai) <dai@debian.org>
 	* amazon.rb: support HTTP Found response and discard wrong stored cache
 

--- a/lib/tdiary/comment_manager.rb
+++ b/lib/tdiary/comment_manager.rb
@@ -14,7 +14,7 @@ module TDiary
 
 		public
 		def add_comment( com )
-			@comments << com
+			(@comments << com).sort!{|a, b| a.date <=> b.date}
 			if not @last_modified or @last_modified < com.date
 				@last_modified = com.date
 			end

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = '5.0.14.20190815'
+	VERSION = '5.0.14.20190817'
 end


### PR DESCRIPTION
いくつかの`IO`が時系列をバラバラにしてツッコミを追加することがあるので、受け取った側で毎回ソートするようにした。
前もってソートすることを`IO`実装時のルールとしても良いが、修正箇所が少ないこちらを採用したい。
欠点として、多数のツッコミを読み込むときに無駄なソート処理がたくさん走るので、性能劣化がある(が無視して良いと考える)。