### PR TITLE
makerss.rb: remove xml-stylesheet

### DIFF
--- a/misc/plugin/makerss.rb
+++ b/misc/plugin/makerss.rb
@@ -324,7 +324,6 @@ def makerss_header( uri )
 	copyright += ", copyright of comments by respective authors"
 
 	%Q[<?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet href="rss.css" type="text/css"?>
 <rdf:RDF xmlns="http://purl.org/rss/1.0/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xml:lang="#{h @conf.html_lang}">
 	<channel rdf:about="#{h rdf_url}">
 	<title>#{h @conf.html_title}</title>

--- a/spec/plugin/makerss_spec.rb
+++ b/spec/plugin/makerss_spec.rb
@@ -1,0 +1,77 @@
+require File.expand_path("../plugin_helper", __FILE__)
+require "rexml/document"
+
+describe "makerss plugin" do
+	before do
+		@conf = PluginFake::Config.new.tap {|conf|
+			conf.plugin_path = "spec/fixtures/plugin"
+			conf.options["base_url"] = "http://example.com/diary/"
+		}
+		@plugin = TDiary::Plugin.new(
+			conf: @conf,
+		).tap {|plugin|
+			plugin.load_plugin("misc/plugin/makerss.rb")
+		}
+	end
+
+	describe "#makerss_header" do
+		subject(:rdf) do
+			REXML::Document.new(@plugin.makerss_header(uri) + "</channel>" + @plugin.makerss_footer)
+				.elements["//rdf:RDF"]
+		end
+		let(:uri) { "http://example.com/test" }
+		let(:channel) { rdf.elements["channel"] }
+		let(:about) { channel.attributes["about"] }
+		let(:description) { channel.elements["description"] }
+		let(:rights) { channel.elements["dc:rights"] }
+
+		before do
+			@conf.html_lang = "ja-JP"
+			@conf.html_title = "<タイトル>"
+			@conf.author_name = "<著者>"
+		end
+
+		it { expect(rdf.attributes["lang"]).to eq(@conf.html_lang) }
+		it { expect(channel.elements["title"].text).to eq(@conf.html_title) }
+		it { expect(channel.elements["link"].text).to eq(uri) }
+		it { expect(channel.elements["dc:creator"].text).to eq(@conf.author_name) }
+
+		context "with makerss.url" do
+			before { @conf["makerss.url"] = "http://example.com/rss" }
+			it { expect(about).to eq(@conf["makerss.url"]) }
+		end
+
+		context "without makerss.url" do
+			before { @conf["makerss.url"] = nil }
+			it { expect(about).to eq(@conf["base_url"] + "index.rdf") }
+		end
+
+		context "with description" do
+			before { @conf["description"] = "<makerss.rbのテスト>" }
+			it { expect(description.text).to eq(@conf.description) }
+		end
+
+		context "without description" do
+			before { @conf["description"] = nil }
+			it { expect(description.text).to eq(nil) }
+		end
+
+		context "with author_mail" do
+			before { @conf.author_mail = "author@example.com" }
+			it do
+				expect(rights.text).to eq(
+					"Copyright #{Time.now.year} #{@conf.author_name} <#{@conf.author_mail}>" \
+					", copyright of comments by respective authors")
+			end
+		end
+
+		context "without author_mail" do
+			before { @conf.author_mail = nil }
+			it do
+				expect(rights.text).to eq(
+					"Copyright #{Time.now.year} #{@conf.author_name}" \
+					", copyright of comments by respective authors")
+			end
+		end
+	end
+end

--- a/spec/plugin/plugin_helper.rb
+++ b/spec/plugin/plugin_helper.rb
@@ -99,7 +99,7 @@ class PluginFake
 
 		attr_accessor :index, :update, :author_name, :author_mail, :index_page,
 			:html_title, :theme, :css, :date_format, :referer_table, :options, :cgi,
-			:plugin_path, :lang, :style,
+			:plugin_path, :lang, :style, :description, :html_lang,
 			:io_class
 
 		def initialize


### PR DESCRIPTION
makerss.rb が出力するXMLには、CSSを適用するための次の行が必ず出力されています。

```
<?xml-stylesheet href="rss.css" type="text/css"?>
```

しかし、RSSにCSSを適用したいケースはあまりない気がします。なので、この行を出力しない設定ができるといいなと思いました。

上記の行を出力しないようにすると、次の些細なメリットがあります。

* rss.cssを取得するHTTP要求が来なくなる。
* index.rdfをウェブブラウザで開いたときにXMLとしてレンダリングされるようになる（このためには #812 の変更も必要）。今のindex.rdfは、各タグの内容だけがレンダリングされてしまうようです。

本PRでは、 `makerss.use_stylesheet` というオプションを追加し、そこに false を設定すれば上記の行が出力されないようにする変更を行っています。互換性を維持するため、このオプションが未設定の場合は今まで通り上記の行を出力するようにしています。

また、 spec/plugin/amp_spec.rb を真似してテストも追加してみました。
