### PR TITLE
update Dockerfile for ruby to 2.6.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt update && apt install -y apt-utils libidn11-dev; \
     gem "tdiary-style-gfm" \n\
     gem "tdiary-style-rd" \n'\
     > Gemfile.local; \
+    gem install bundler && \
     bundle --path=vendor/bundle --without=development:test --jobs=4 --retry=3
 
 COPY . /usr/src/app/


### PR DESCRIPTION
bundler 2.0.2が必要だったのでDockerfile内で`gem install bundler`するようにした。