### PR TITLE
support Amazon plugin on PA-API v5

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-11-24  Tada, Tadashi <t@tdtds.jp>
+	* amazon.rb: update to use PA-API v5
+
 2019-08-17  Tada, Tadashi <t@tdtds.jp>
 	* sort commants by date on a new comment added
 

--- a/lib/aws/pa_api.rb
+++ b/lib/aws/pa_api.rb
@@ -36,6 +36,7 @@ module AWS
 					"Images.Primary.Small",
 					"Images.Primary.Medium",
 					"Images.Primary.Large",
+					"ItemInfo.ByLineInfo",
 					"ItemInfo.Title",
 					"Offers.Listings.Price"
 				]
@@ -57,6 +58,8 @@ module AWS
 			http = Net::HTTP.new(uri.host, uri.port)
 			http.use_ssl = true
 			response = http.post(uri.path, payload, headers)
+			response.value # raise on errors
+			return response.body
 		end
 	end
 end

--- a/lib/aws/pa_api.rb
+++ b/lib/aws/pa_api.rb
@@ -1,0 +1,62 @@
+require 'aws/sig_v4'
+require 'json'
+require 'net/http'
+
+module AWS
+	class PAAPI
+		Market = Struct.new(:host, :region)
+		MARKETS = {
+			au: Market.new('webservices.amazon.com.au', 'us-west-2'),
+			br: Market.new('webservices.amazon.com.br'  'us-east-1'),
+			ca: Market.new('webservices.amazon.ca',     'us-east-1'),
+			fr: Market.new('webservices.amazon.fr',     'eu-west-1'),
+			de: Market.new('webservices.amazon.de',     'eu-west-1'),
+			in: Market.new('webservices.amazon.in',     'eu-west-1'),
+			it: Market.new('webservices.amazon.it',     'eu-west-1'),
+			jp: Market.new('webservices.amazon.co.jp',  'us-west-2'),
+			mx: Market.new('webservices.amazon.com.mx', 'us-east-1'),
+			es: Market.new('webservices.amazon.es',     'eu-west-1'),
+			tr: Market.new('webservices.amazon.com.tr', 'eu-west-1'),
+			ae: Market.new('webservices.amazon.ae',     'eu-west-1'),
+			uk: Market.new('webservices.amazon.co.uk',  'eu-west-1'),
+			us: Market.new('webservices.amazon.com',    'us-east-1'),
+		}.freeze
+
+		def initialize(access_key, secret_key, partner_tag)
+			@access_key, @secret_key, @partner_tag = access_key, secret_key, partner_tag
+		end
+
+		def get_items(asin, locale)
+			payload = {
+				"PartnerTag" => @partner_tag,
+				"PartnerType" => "Associates",
+				"Marketplace" => MARKETS[locale].host.sub('webservices', 'www'),
+				"ItemIds" => [asin],
+				"Resources" => [
+					"Images.Primary.Small",
+					"Images.Primary.Medium",
+					"Images.Primary.Large",
+					"ItemInfo.Title",
+					"Offers.Listings.Price"
+				]
+			}.to_json
+			time_stamp = Time.now.utc.strftime("%Y%m%dT%H%M%SZ")
+			signature = AWS::SigV4.signature(@secret_key, time_stamp, MARKETS[locale].region, MARKETS[locale].host, payload)
+			authorization = "AWS4-HMAC-SHA256 Credential=#{@access_key}/#{time_stamp[0,8]}/#{MARKETS[locale].region}/ProductAdvertisingAPI/aws4_request, SignedHeaders=content-encoding;host;x-amz-content-sha256;x-amz-date;x-amz-target, Signature=#{signature}"
+
+			headers = {
+				"X-Amz-Target" => "com.amazon.paapi5.v1.ProductAdvertisingAPIv1.GetItems",
+				"Content-Encoding" => "amz-1.0",
+				"Host" => MARKETS[locale].host,
+				"X-Amz-Date" => time_stamp,
+				"X-Amz-Content-Sha256" => OpenSSL::Digest::SHA256.hexdigest(payload),
+				"Authorization" => authorization,
+				"Content-Type" => "application/json; charset=utf-8"
+			}
+			uri = URI("https://#{MARKETS[locale].host}/paapi5/getitems")
+			http = Net::HTTP.new(uri.host, uri.port)
+			http.use_ssl = true
+			response = http.post(uri.path, payload, headers)
+		end
+	end
+end

--- a/lib/aws/pa_api.rb
+++ b/lib/aws/pa_api.rb
@@ -27,6 +27,7 @@ module AWS
 		end
 
 		def get_items(asin, locale)
+			asin = isbn13to10(asin) if asin.length == 13
 			payload = {
 				"PartnerTag" => @partner_tag,
 				"PartnerType" => "Associates",
@@ -60,6 +61,12 @@ module AWS
 			response = http.post(uri.path, payload, headers)
 			response.value # raise on errors
 			return response.body
+		end
+
+	private
+		def isbn13to10(isbn13)
+			sum, = isbn13[3, 9].split(//).map(&:to_i).reduce([0,10]){|s,d|[s[0] + d * s[1], s[1]-1]}
+			return isbn13[3, 9] + %w(0 1 2 3 4 5 6 7 8 9 X 0)[11 - sum % 11]
 		end
 	end
 end

--- a/lib/aws/sig_v4.rb
+++ b/lib/aws/sig_v4.rb
@@ -1,0 +1,45 @@
+#
+# A Simple impl of AWS Signature V4 for PA-API GetItems
+#
+require 'openssl'
+
+module AWS
+	module SigV4
+		def self.canonical_request(host, payload, time_stamp)
+			headers = {
+				'Content-Encoding' => 'amz-1.0',
+				'Host' => host,
+				'X-Amz-Content-Sha256' => OpenSSL::Digest::SHA256.hexdigest(payload),
+				'X-Amz-Date' => time_stamp,
+				'X-Amz-Target' => "com.amazon.paapi5.v1.ProductAdvertisingAPIv1.GetItems",
+			}
+			[
+				"POST",
+				"/paapi5/getitems",
+				'',
+				headers.keys.sort.map{|k|"#{k.downcase}:#{headers[k]}"}.join("\n") + "\n",
+				headers.keys.sort.map{|k|k.downcase}.join(';'),
+				OpenSSL::Digest::SHA256.hexdigest(payload)
+			].join("\n")
+		end
+		def self.string2sign(host, payload, time_stamp)
+			[
+				'AWS4-HMAC-SHA256',
+				time_stamp,
+				"#{time_stamp[0,8]}/us-west-2/ProductAdvertisingAPI/aws4_request",
+				OpenSSL::Digest::SHA256.hexdigest(canonical_request(host, payload, time_stamp))
+			].join("\n")
+		end
+		def self.signature(secret, time_stamp, region, host, payload)
+			k_secret = secret
+			k_date = hmac("AWS4" + k_secret, time_stamp[0,8])
+			k_region = hmac(k_date, region)
+			k_service = hmac(k_region, 'ProductAdvertisingAPI')
+			k_credential = hmac(k_service, "aws4_request")
+			OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), k_credential, string2sign(host, payload, time_stamp))
+		end
+		def self.hmac(key, value)
+			OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), key, value)
+		end
+	end
+end

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = '5.0.14.20190817'
+	VERSION = '5.0.14.20191124'
 end

--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -160,7 +160,6 @@ def amazon_get(asin, with_image = true, label = nil, pos = 'amazon')
 			partner_tag = @conf['amazon.aid']
 			paapi = AWS::PAAPI.new(access_key, secret_key, partner_tag)
 			json = paapi.get_items(asin, country.to_sym)
-			p json
 			File::open("#{cache}/#{country}#{asin}.json", 'wb'){|f| f.write(json)}
 		end
 		item = json["ItemsResult"]["Items"][0]


### PR DESCRIPTION
Amazon PA-APIのv5への移行期限が11月末までに迫っているので実装。

* lib/awsの下に関連ライブラリを実装した
* amazon.rbのインタフェースはできるだけ変えない
* 認証proxyは廃止の方向で(API利用に制限がありすぎて開放する意味がなくなっている)