### PR TITLE
add svg icon image type

### DIFF
--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -314,6 +314,8 @@ def icon_tag
 	if @conf.icon and not(@conf.icon.empty?) then
 		if /\.ico$/ =~ @conf.icon then
 			%Q[<link rel="shortcut icon" href="#{h @conf.icon}">]
+		elsif /\.svg$/ =~ @conf.icon then
+			%Q[<link rel="icon" href="#{h @conf.icon}" type="image/svg+xml">]
 		else
 			%Q[<link rel="icon" href="#{h @conf.icon}">]
 		end


### PR DESCRIPTION
favicon・サイトアイコンはそろそろSVGもかなりのブラウザで使えるようになっているのでSVGを指定したときに  `type="image/svg+xml"` を付けるようにしてみました。

## 参考

- https://caniuse.com/#search=svg%20favicon
![image](https://user-images.githubusercontent.com/118150/76426203-155cf000-63ee-11ea-8761-6c9491717b0d.png)

