### PR TITLE
category-legacy.rb使用時に全カテゴリ表示が正しく表示されない

### DIFF
--- a/js/category.js
+++ b/js/category.js
@@ -28,6 +28,8 @@ $(function(){
 	});
 
 	// reverse list of category
-	var list = $('ul.category li').toArray().reverse();
-	$('ul.category').empty().append(list);
+	$('ul.category').each(function(){
+		var ul = $(this);
+		ul.append(ul.children().toArray().reverse());
+	});
 });

--- a/misc/plugin/category-legacy.rb
+++ b/misc/plugin/category-legacy.rb
@@ -597,7 +597,7 @@ def category_edit_support_dropdown
 	ret
 end
 
-if @conf['category.edit_support'] != 0 then
+if @mode =~ /^(form|edit)$/ and @conf['category.edit_support'] != 0 then
 	enable_js( 'category.js' )
 	add_edit_proc do |date|
 		ret = ''
@@ -611,6 +611,9 @@ if @conf['category.edit_support'] != 0 then
 	end
 end
 
+if @mode =~ /^categoryview$/ and @conf['category.show_reverse']
+	enable_js('category.js')
+end
 
 #
 # when update diary, update cache
@@ -695,6 +698,7 @@ if @mode == 'conf' || @mode == 'saveconf'
 				@conf["category.period"] = @cgi.params["category.period"][0]
 			end
 			@conf['category.edit_support'] = (@cgi.params['category.edit_support'][0] || '1').to_i
+			@conf['category.show_reverse'] = !!(@cgi.params['category.show_reverse'][0] == 'true')
 		end
 		category_conf_html
 	end

--- a/misc/plugin/en/category-legacy.rb
+++ b/misc/plugin/en/category-legacy.rb
@@ -71,6 +71,11 @@ Category names can be shown under the 'Article' form.
 </select>
 </p>
 
+<h3 class="subtitle">Display Order</h3>
+<p><label for="category.show_reverse">
+<input type="checkbox" id="category.show_reverse" name="category.show_reverse" value="true"#{" checked" if @conf['category.show_reverse']}>Sorts the list from newest to oldest
+</label></p>
+
 <h3 class="subtitle">Default period</h3>
 <p>
 Specify the default display period for category view.

--- a/misc/plugin/ja/category-legacy.rb
+++ b/misc/plugin/ja/category-legacy.rb
@@ -73,6 +73,11 @@ def category_conf_html
 </select>
 </p>
 
+<h3 class="subtitle">表示順</h3>
+<p><label for="category.show_reverse">
+<input type="checkbox" id="category.show_reverse" name="category.show_reverse" value="true"#{" checked" if @conf['category.show_reverse']}>リストを新しい順に表示
+</label></p>
+
 <h3 class="subtitle">表示期間の初期状態</h3>
 <p>
 カテゴリ表示画面を表示した時の、最初の表示期間を指定します。


### PR DESCRIPTION
バージョン5.1.1から、プラグインのcategory-legacy.rbを使用している場合にカテゴリ別表示の画面が正しく表示されなくなっているようです。

category-legacy.rbではカテゴリ別表示の画面にて全カテゴリの記事一覧を同時に表示することができますが、そうした場合に各カテゴリに全カテゴリ分の記事一覧が表示されてしまいます。

* カテゴリA
    * 記事タイトル1
    * 記事タイトル2
* カテゴリB
    * 記事タイトル3
    * 記事タイトル4

と表示されるべきときに

* カテゴリA
    * 記事タイトル1
    * 記事タイトル2
    * 記事タイトル3
    * 記事タイトル4
* カテゴリB
    * 記事タイトル1
    * 記事タイトル2
    * 記事タイトル3
    * 記事タイトル4

のように表示されてしまいます。

#866 でcategory.jsに逆順表示処理が追加されたのが原因のようなので、category-legacy.rb使用時でも動くようにするpull requestを作成しました。