### PR TITLE
calendar2 plugin: fix wrong calendar in next/prev diaries mode

### DIFF
--- a/misc/plugin/calendar2.rb
+++ b/misc/plugin/calendar2.rb
@@ -46,12 +46,8 @@ def calendar2_make_cal(year, month)
 	result
 end
 
-def calendar2_prev_current_next
-	yyyymm = if /^(latest|search)$/ =~ @mode
-					Time.now
-				else
-					@date
-				end.strftime "%Y%m"
+def calendar2_prev_current_next(date)
+	yyyymm = date.strftime "%Y%m"
 	yms = [yyyymm]
 	@years.keys.each do |y|
 		yms |= @years[y].collect {|i| y + i}
@@ -95,14 +91,11 @@ def calendar2(days_format = nil, navi_format = nil, show_todo = nil)
 	navi_format ||= @calendar2_navi_format
 
 	return '' if /TAMATEBAKO/ =~ @cgi.user_agent
-	date = if /^(latest|search)$/ =~ @mode
-				Time.now
-			else
-				@date
-			end
+	date = @date || @diaries.values.map{|v|v.date}.sort.first || Time.now
+	                # adopt the oldest date in @diaries
 	year = date.year
 	month = date.month
-	p_c_n = calendar2_prev_current_next
+	p_c_n = calendar2_prev_current_next(date)
 
 	result = <<CALENDAR_HEAD
 <table class="calendar" title="calendar">


### PR DESCRIPTION
calendar2プラグインで「前N日分」「次N日分」表示のとき、適切なカレンダーが表示されず、また存在する日記へのリンクが生成されない問題を修正。表示する月は以下の日付をベースにする (上から順にトライする):

1. `@date`があればその日付
2. `@diaries` に含まれる最古の日付
3. 現在時刻

副次効果として、長期間更新されていない日記で最新の日記に合わせたカレンダーが表示されるようになる。

だいたいの場合これで大丈夫だが、例外的におかしなカレンダーが表示される場合もある(たとえばN年日記モード)が、そもそも単一の月カレンダーで表現できないページなのであきらめる。