### PR TITLE
suppurt OmniAuth2

### DIFF
--- a/lib/tdiary/rack/auth/omniauth.rb
+++ b/lib/tdiary/rack/auth/omniauth.rb
@@ -19,6 +19,7 @@ class TDiary::Rack::Auth::OmniAuth
 			raise NoStrategyFoundError.new("Not found any strategies. Write the omniauth strategy in your Gemfile.local.")
 		end
 
+		OmniAuth.config.allowed_request_methods = [:get] # FixMe
 		@app = ::Rack::Builder.new(app) {
 			use TDiary::Rack::Session
 		}.tap {|builder|


### PR DESCRIPTION
OmniAuth2をとりあえずサポートする。

一時的に `OmniAuth.config.allowed_request_methods` へ `:get` を指定することで従来の動作(GETメソッドによる認可処理)を指定している。ただしこれはCSRFのリスクがあるので推奨されない。最終的にはPOSTを使うようにすべきである。