### PR TITLE
Change build status URLs to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://www.heroku.com/deploy?template=https://github.com/tdiary/tdiary-core)
 
-[![Gem Version](https://badge.fury.io/rb/tdiary.png)](https://rubygems.org/gems/tdiary) [![Build Status](https://secure.travis-ci.org/tdiary/tdiary-core.png)](https://travis-ci.org/tdiary/tdiary-core) [![Coverage Status](https://coveralls.io/repos/tdiary/tdiary-core/badge.png?branch=master)](https://coveralls.io/r/tdiary/tdiary-core) [![Code Climate](https://codeclimate.com/github/tdiary/tdiary-core.png)](https://codeclimate.com/github/tdiary/tdiary-core)
+[![Gem Version](https://badge.fury.io/rb/tdiary.png)](https://rubygems.org/gems/tdiary) [![Build Status](https://github.com/tdiary/tdiary-core/actions/workflows/ci.yml/badge.svg)](https://github.com/tdiary/tdiary-core/actions/workflows/ci.yml) [![Coverage Status](https://coveralls.io/repos/tdiary/tdiary-core/badge.png?branch=master)](https://coveralls.io/r/tdiary/tdiary-core) [![Code Climate](https://codeclimate.com/github/tdiary/tdiary-core.png)](https://codeclimate.com/github/tdiary/tdiary-core)
 
 ## tDiary, The TSUKKOMI-able Weblog.
 


### PR DESCRIPTION
[tDiary-5.1.5 リリースノート](https://tdiary.org/20210228.html)でCI環境がGitHub Actionsへ移行されたことを知り、Travisはもう使われていないようなので、プロジェクトのビルドステータスを表すバッジとリンク先もGitHub ActionsのURLに変更しました。

生成されるバッジ画像の見た目は[.github/workflows/ci.yml](https://github.com/tdiary/tdiary-core/blob/master/.github/workflows/ci.yml)の `name` が参照されるため、「ubuntu」が表示されます。

![image](https://user-images.githubusercontent.com/221802/113514625-c2327e00-95aa-11eb-9900-9c9b69787179.png)
