### PR TITLE
Removed vendored bundler files 

### DIFF
--- a/lib/tdiary/tasks/release.rake
+++ b/lib/tdiary/tasks/release.rake
@@ -57,9 +57,6 @@ begin
 					}
 					FileUtils.rm_rf current unless versions.member?(current)
 				end
-				Dir.chdir 'misc/lib' do
-					sh 'gem unpack bundler'
-				end
 			end
 		end
 


### PR DESCRIPTION
Because Ruby 2.6+ bundled bundler as the default gems.

Fixes https://github.com/tdiary/tdiary-core/issues/884