### PR TITLE
Handle and print raw URL when amazon returned 429 error

### DIFF
--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -185,7 +185,12 @@ def amazon_get(asin, with_image = true, label = nil, pos = 'amazon')
 		if @mode == 'preview' then
 			message << %Q|<span class="message">(#{h e.message})</span>|
 		end
-		message
+		# Handle 429 "Too Many Requests"
+		if /^429/ =~ e.message then
+			%Q|<a href="https://www.amazon.co.jp/dp/#{h asin}">https://www.amazon.co.jp/dp/#{h asin}</a>|
+		else
+			message
+		end
 	rescue NoMethodError
 		@logger.error "amazon.rb: #{json["Errors"][0]["Message"]}"
 		message = label || asin


### PR DESCRIPTION
Amazon での売り上げが一定期間ない時に Amazon PA API は `429 "Too Many Requests"` を返し続けるようで、その時にひたすら ASIN が文字列でだけ表示されても日記としては読者の役に立たないのですごく雑にリンクを作るようにしました。

これにアソシエイトタグをつけた方がいいのかどうしたもんでしょうか。