### PR TITLE
fix #967 error in `String#encode` cause by keyword parameter incompatible

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2021-11-14 Tada, Tadashi <t@tdtds.jp>
+	* fix error in `String#encode` cause by keyword parameter incompatible
+
 2021-08-29 Tada, Tadashi <t@tdtds.jp>
 	* fix heroku button: add MONGODB_URI into env section
 	* release 5.1.7

--- a/lib/tdiary/lang/ja.rb
+++ b/lib/tdiary/lang/ja.rb
@@ -22,11 +22,11 @@ def mobile_encoding
 end
 
 def to_mobile( str )
-	str.encode(mobile_encoding, {invalid: :replace, undef: :replace})
+	str.encode(mobile_encoding, invalid: :replace, undef: :replace)
 end
 
 def to_mail( str )
-	str.encode('iso-2022-jp', {invalid: :replace, undef: :replace})
+	str.encode('iso-2022-jp', invalid: :replace, undef: :replace)
 end
 
 def migrate_to_utf8( str )


### PR DESCRIPTION
キーワード引数の非互換で、メールへのエンコード処理がエラーになっていた。`String#encode` のパラメタをHashではなくキーワード引数に修正。