### PR TITLE
fix debugging on vscode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2021-11-14 Tada, Tadashi <t@tdtds.jp>
 	* fix error in `String#encode` cause by keyword parameter incompatible
+	* fix debugging on vscode
 
 2021-08-29 Tada, Tadashi <t@tdtds.jp>
 	* fix heroku button: add MONGODB_URI into env section

--- a/lib/tdiary/cli.rb
+++ b/lib/tdiary/cli.rb
@@ -100,6 +100,7 @@ module TDiary
 		def server
 			require 'tdiary'
 			require 'tdiary/environment'
+			require 'webrick'
 
 			if options[:cgi]
 				opts = {
@@ -113,7 +114,6 @@ module TDiary
 			elsif
 				# --rack option
 				# Rack::Server reads ARGV as :config, so delete it
-				require 'webrick'
 				ARGV.shift
 				opts = {
 					environment: ENV['RACK_ENV'] || "development",


### PR DESCRIPTION
vscodeのデバッグで `tdiary server` コマンドが動かなかったのを修正。
`require 'webrick'`がサイレントで死ぬのだが(謎)、`if` の外に移動してみたら動いたので、とりあえずこれで。