### PR TITLE
amazon.rb :  429 Too Many Requests が返ってきたときのリンクに label を使用する

### DIFF
--- a/misc/plugin/amazon.rb
+++ b/misc/plugin/amazon.rb
@@ -181,16 +181,17 @@ def amazon_get(asin, with_image = true, label = nil, pos = 'amazon')
 		message
 	rescue Net::HTTPResponse, Net::HTTPExceptions => e
 		@logger.error "amazon.rb: #{e.message}"
-		message = label || asin
+		message = ''
+		# Handle 429 "Too Many Requests"
+		if /^429/ =~ e.message then
+			url = "https://www.amazon.co.jp/dp/#{h asin}"
+			label ||= url
+			message << %Q|<a href="#{h url}">#{h label}</a>|
+		end
 		if @mode == 'preview' then
 			message << %Q|<span class="message">(#{h e.message})</span>|
 		end
-		# Handle 429 "Too Many Requests"
-		if /^429/ =~ e.message then
-			%Q|<a href="https://www.amazon.co.jp/dp/#{h asin}">https://www.amazon.co.jp/dp/#{h asin}</a>|
-		else
-			message
-		end
+		message
 	rescue NoMethodError
 		@logger.error "amazon.rb: #{json["Errors"][0]["Message"]}"
 		message = label || asin


### PR DESCRIPTION
`{{isbn '0000000000', 'hoge'}}` のような使い方をしていて `429` が返ってきた際に、label を含むリンクを作るようにしました。