### PR TITLE
image.js: 日記更新画面で画像をクリックしたときの動作を修正

### DIFF
--- a/js/image.js
+++ b/js/image.js
@@ -11,13 +11,13 @@ function insertImage(text){
 }
 
 $(function(){
-	$('.image-img')
-	.on('hover', function(){
+	$(document)
+	.on('hover', '.image-img', function(){
 		$(this).css('cursor', 'pointer');
 	}, function(){
 		$(this).css('cursor', 'default');
 	})
-	.on('click', function(){
+	.on('click', '.image-img', function(){
 		var idx = this.id.replace('image-index-', '');
 		var w = $('#image-info-' + idx + ' .image-width').text();
 		var h = $('#image-info-' + idx + ' .image-height').text();


### PR DESCRIPTION
### 問題
imageプラグイン使用時、日記の更新画面で次の操作をしたときにimageプラグイン呼び出しの記述（Wikiスタイルだと `{{image 0, '画像の説明', nil, [100, 100]}}` というような記述）が本文に追加されません。
1. 日記の更新画面の「絵日記（追加）」欄で画像をアップロードする。
2. 「絵日記(一覧・削除)」欄に追加された画像をクリックする。

日記の更新画面を開いたときに「絵日記(一覧・削除)」欄に元々表示されていた画像をクリックしたときには正しく動作します。
画像のアップロードと画像のクリックを続けて行おうとしたときに正しく動作しません。

### 原因
#545 でjQueryの `live()` の代わりに `on()` を使うように修正が行われています。
しかし、単純に置き換えるだけだと `live()` にあった「後から追加された要素に対してもイベントハンドラを設定する」という機能が有効にならず、その結果上に書いた問題が発生するのだと思います。

### 修正内容
https://api.jquery.com/live/#entry-longdesc
にある例のように `on()` にselectorを指定するようにすると `live()` と同じ挙動になるようなので、そのように修正しました。

### その他
このPRで修正しているのは `.image-img` というセレクターに対する処理だけです。
#545 ではこれ以外に `#plugin-image-delimage` というセレクターに対する `live()` も `on()` に変更しています。こちらも同様の修正をした方がいいのかもしれませんが、現状で問題が発生するような操作を見つけられなかったのでこちらには手を付けていません。
