### PR TITLE
avoid Rack::Lint::LintError (partial fix #1050)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,5 @@ VOLUME [ "/usr/src/app/data", "/usr/src/app/public" ]
 EXPOSE 9292
 ENV PORT=9292
 ENV HTPASSWD=data/.htpasswd
+ENV RACK_ENV=deployment
 CMD bundle exec rackup -o 0.0.0.0 -p ${PORT}


### PR DESCRIPTION
Rack 3.0の非互換で、HTTP header を小文字で指定しないとRack::Lint::LintError が発生するのを、一時的に回避する。