### PR TITLE
Make cases lower for Location

### DIFF
--- a/lib/tdiary/rack/auth/omniauth/authorization.rb
+++ b/lib/tdiary/rack/auth/omniauth/authorization.rb
@@ -32,7 +32,7 @@ module TDiary
 						req = ::Rack::Request.new(env)
 						env['rack.session']['tdiary.auth.redirect'] = "#{req.base_url}#{req.fullpath}"
 						redirect = File.join("#{req.base_url}#{req.path}", "#{::OmniAuth.config.path_prefix}/#{@provider}")
-						[302, {'content-type' => 'text/plain', 'Location' => redirect}, []]
+						[302, {'content-type' => 'text/plain', 'location' => redirect}, []]
 					end
 
 					def logout(env)
@@ -51,7 +51,7 @@ module TDiary
 						env['rack.session']['auth'] = auth
 						env['REMOTE_USER'] = "#{auth.uid}@#{auth.provider}"
 						redirect = env['rack.session']['tdiary.auth.redirect'] || '/'
-						[302, {'content-type' => 'text/plain', 'Location' => redirect}, []]
+						[302, {'content-type' => 'text/plain', 'location' => redirect}, []]
 					end
 
 					def authenticate?(env)


### PR DESCRIPTION
Twitter でOAuth しようとすると Location ヘッダが大文字であることで lint エラーが出ました。
https://github.com/tdiary/tdiary-core/pull/1068 の続きかも知れません。
小文字にするとログインできました。
