### PR TITLE
Use official services context for memcached

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,17 @@ jobs:
         ruby: [ '3.3', '3.2', '3.1', '3.0' ]
         test_mode: [ rack, gem ]
     runs-on: ubuntu-latest
+    services:
+      memcached:
+        image: memcached:latest
+        ports:
+          - 11211:11211
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - uses: niden/actions-memcached@v7
     - run: |
         gem install bundler --no-document -v '2.4.22'
       if: matrix.ruby == '2.7'


### PR DESCRIPTION
niden/actions-memcached@v7 is not working today

see https://github.com/tdiary/tdiary-core/actions/runs/10515580853/job/29135950931?pr=1171#step:5:4