### PR TITLE
Workaround for Rackup-2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rack', "< 3.1"
-gem 'rackup', "< 2.2"
+gem 'rackup'
 gem 'hikidoc'
 gem 'fastimage'
 gem 'emot'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,9 +96,8 @@ GEM
     racksh (1.0.1)
       rack (>= 1.0)
       rack-test (>= 0.5)
-    rackup (2.1.0)
+    rackup (2.2.1)
       rack (>= 3)
-      webrick (~> 1.8)
     rake (13.2.1)
     redcarpet (3.6.0)
     regexp_parser (2.10.0)
@@ -178,7 +177,7 @@ DEPENDENCIES
   pit
   rack (< 3.1)
   racksh
-  rackup (< 2.2)
+  rackup
   rake
   redcarpet
   rexml

--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -1,0 +1,4 @@
+require 'rackup/server'
+module Rack
+  Server = ::Rackup::Server
+end


### PR DESCRIPTION
Rackup-2.2.x removed `rack/server`. But we couldn't migrate jasmine 3.x yet.