### PR TITLE
Explicitly load Rackup::Handler::CGI

### DIFF
--- a/index.rb
+++ b/index.rb
@@ -32,6 +32,7 @@ begin
 	status, headers, body = TDiary::Dispatcher.index.dispatch_cgi( request, @cgi )
 
 	TDiary::Dispatcher.send_headers( status, headers )
+	require 'rackup/handler/cgi'
 	::Rackup::Handler::CGI.send_body(body)
 rescue Exception
 	if @cgi then

--- a/update.rb
+++ b/update.rb
@@ -32,6 +32,7 @@ begin
 	status, headers, body = TDiary::Dispatcher.update.dispatch_cgi( request, @cgi )
 
 	TDiary::Dispatcher.send_headers( status, headers )
+	require 'rackup/handler/cgi'
 	::Rackup::Handler::CGI.send_body(body)
 rescue Exception
 	if @cgi then


### PR DESCRIPTION
rackup/handler/cgi is removed from rackup.rb at https://github.com/rack/rackup/commit/be545952432d0f03c954c56413a9535212ac71d5