### PR TITLE
Use cgi gem, not stdlib with >= Ruby 4.0

### DIFF
--- a/lib/tdiary.rb
+++ b/lib/tdiary.rb
@@ -16,6 +16,7 @@ $:.unshift File.join(File::dirname(__FILE__), '../misc/lib')
 	Dir[File.join(File.dirname(__FILE__), path)].each {|dir| $:.unshift dir }
 end
 
+gem 'cgi' if RUBY_VERSION >= '4.0'
 require 'cgi'
 require 'uri'
 require 'fileutils'

--- a/misc/lib/fcgi_patch.rb
+++ b/misc/lib/fcgi_patch.rb
@@ -15,6 +15,7 @@ Patch written by:
 
 class FCGI
   def self::each_cgi(*args)
+    gem 'cgi' if RUBY_VERSION >= '4.0'
     require 'cgi'
 
     eval(<<-EOS,TOPLEVEL_BINDING)

--- a/tdiary.gemspec
+++ b/tdiary.gemspec
@@ -44,5 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rake'
   spec.add_dependency 'thor'
   spec.add_dependency 'rexml'
+  spec.add_dependency 'cgi'
   spec.add_dependency 'webrick'
 end


### PR DESCRIPTION
`cgi` library has been removed at Ruby 4.0, we should use gem version of `cgi` library.