### PR TITLE
Use Array#max/min instead of sorting to pick boundary date keys

### DIFF
--- a/lib/tdiary/plugin/05referer.rb
+++ b/lib/tdiary/plugin/05referer.rb
@@ -55,7 +55,7 @@ class RefererDiary
 	alias :add_referer_orig :add_referer
 	def add_referer( ref, count = 1 )
 		return nil unless ref
-		current = @current_date || @refs.keys.sort[-1] || '00000101'
+		current = @current_date || @refs.keys.max || '00000101'
 		ref_info = add_referer_orig( ref, count )
 		uref = CGI::unescape( ref )
 		@refs[current] ||= {}
@@ -67,7 +67,7 @@ class RefererDiary
 	end
 
 	def clear_oldest_referer( newest )
-		return if (@refs.keys.sort[-1] || '') > newest
+		return if (@refs.keys.max || '') > newest
 		@refs[newest] = {} unless @refs[newest]
 		return if @refs.keys.size <= @keep
 		@refs.delete( @refs.keys.sort[0] )
@@ -97,9 +97,9 @@ end
 
 def latest_day?( diary )
 	return false unless diary
-	y = @years.keys.sort[-1]
-	m = @years[y].sort[-1]
-	diary.date.year == y.to_i and diary.date.month == m.to_i and diary.date.day == @diaries.keys.sort[-1][6,2].to_i
+	y = @years.keys.max
+	m = @years[y].max
+	diary.date.year == y.to_i and diary.date.month == m.to_i and diary.date.day == @diaries.keys.max[6,2].to_i
 end
 
 def referer_update( diary )

--- a/lib/tdiary/plugin/05referer.rb
+++ b/lib/tdiary/plugin/05referer.rb
@@ -70,7 +70,7 @@ class RefererDiary
 		return if (@refs.keys.max || '') > newest
 		@refs[newest] = {} unless @refs[newest]
 		return if @refs.keys.size <= @keep
-		@refs.delete( @refs.keys.sort[0] )
+		@refs.delete( @refs.keys.min )
 	end
 
 	alias :each_referer_orig :each_referer

--- a/lib/tdiary/view.rb
+++ b/lib/tdiary/view.rb
@@ -261,7 +261,7 @@ module TDiary
 					@date = date
 					@io.transaction( @date ) do |diaries|
 						@diaries = diaries
-						@diary = @diaries[@diaries.keys.sort.reverse[0]]
+						@diary = @diaries[@diaries.keys.max]
 						DIRTY_NONE
 					end
 				end
@@ -341,7 +341,7 @@ module TDiary
 								break
 							end
 						end
-						@diary = @diaries[@diaries.keys.sort.reverse[0]] unless @diary
+						@diary = @diaries[@diaries.keys.max] unless @diary
 						@date = @diary.date if @diary
 					end
 					DIRTY_NONE

--- a/misc/plugin/calendar2.rb
+++ b/misc/plugin/calendar2.rb
@@ -90,7 +90,7 @@ def calendar2(days_format = nil, navi_format = nil, show_todo = nil)
  	days_format ||= @calendar2_days_format
 	navi_format ||= @calendar2_navi_format
 
-	date = @date || @diaries.values.map{|v|v.date}.sort.first || Time.now
+	date = @date || @diaries.values.map{|v|v.date}.min || Time.now
 	                # adopt the oldest date in @diaries
 	year = date.year
 	month = date.month


### PR DESCRIPTION
Several spots selected the newest or oldest diary date by building a full sorted array and then taking its first or last element, and in one case reversing it first. Picking a single boundary value only needs Array#max or Array#min, which scans once and avoids allocating the throwaway sorted and reversed arrays.

This touches the latest-diary lookup in TDiaryView and the newest/oldest key handling in the referer and calendar2 plugins. Behavior is unchanged because max and min order keys the same way sort does, including returning nil on an empty collection.
