### PR TITLE
Shrink and widen the diary editor textarea

### DIFF
--- a/theme/base.css
+++ b/theme/base.css
@@ -285,10 +285,14 @@ div.youtube-player-wrapper {
 
 /*
  * editor textarea sizing
+ *
+ * Widen the editor 10% past the form column, splitting the overflow
+ * evenly on both sides so it stays centered with the fields around it.
  */
 textarea#body {
 	box-sizing: border-box;
-	width: 100%;
-	height: clamp(15rem, 50dvh, 50rem);
+	width: 110%;
+	margin-inline: -5%;
+	height: clamp(10rem, 33dvh, 33rem);
 	resize: vertical;
 }


### PR DESCRIPTION
The diary editor textarea was taller than it needed to be and only as
wide as the form column. Cut its height to two-thirds and stretch it 10%
past the column so more of the entry is visible without scrolling. The
overflow is split evenly on both sides with negative inline margins so
the textarea stays centered with the title and draft fields around it.
