### PR TITLE
Release the gem via trusted publishing on tag push

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -15,13 +15,12 @@ assignees: ''
   - blogkitの lib/tdiary/blogkit/version.rb
   - contribの lib/tdiary/contrib/version.rb
 - [ ] core / blogkit / contrib / theme に tag を打つ (`git pull --tags; git tag vL.M.N; git push origin vL.M.N`)
-  - coreはtag pushで `.github/workflows/release.yml` が起動し、trusted publishing で gem を rubygems.org に publish、GitHub Release を自動作成する。`.github/workflows/build-image.yml` が Docker イメージも build/push する
-- [ ] coreの [Actions](https://github.com/tdiary/tdiary-core/actions) で Release ワークフローの成功と、rubygems.org / GitHub Release / Docker イメージへの反映を確認する
+  - coreはtag pushで `.github/workflows/release.yml` が起動し、trusted publishing で gem を rubygems.org に publish、GitHub Release の自動作成と full tarball の添付まで行う。`.github/workflows/build-image.yml` が Docker イメージも build/push する
+- [ ] coreの [Actions](https://github.com/tdiary/tdiary-core/actions) で Release ワークフローの成功と、rubygems.org / GitHub Release (full tarball 添付含む) / Docker イメージへの反映を確認する
 - [ ] 自動生成された core の [GitHub Release](https://github.com/tdiary/tdiary-core/releases) のノートを必要に応じて加筆する
 - [ ] 以下の各リポジトリ配下で`bundle clean; bundle exec rake release` コマンドを実行する (gemを最新にしてrubygemsにアップロード)
   - blogkit
   - contrib
-- [ ] (Phase 2 実装までの暫定) full tarball を GitHub Release に添付する場合は、core配下で `bundle exec rake package:stable` を実行し tmp 配下の tar.gz を手動でアップロードする (`package:release` と GITHUB_ACCESS_TOKEN による自動アップロードは廃止。CI での自動生成・添付は別途対応予定)
 - [ ] themeのmasterブランチをgh-pagesブランチへmerge、pushする (`git checkout gh-pages; git merge master; git push origin gh-pages`)
 - [ ] tdiary.org の以下のエントリーを書く
   - [ダウンロード](https://github.com/tdiary/tdiary.github.io/blob/master/download.md)

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -8,21 +8,21 @@ assignees: ''
 ---
 
 リリース作業リスト
-- [ ] lib/tdiary/tasks/release.rake` と `.github/workflow/ci.yml` に今回サポートを追加/停止するrubyのバージョンが含まれるか確認、修正する
-- [ ] [releases](https://github.com/tdiary/tdiary-core/releases)にエントリを追加してリリースノートを書く
+- [ ] core の `lib/tdiary/tasks/release.rake` と `.github/workflows/ci.yml` に今回サポートを追加/停止するrubyのバージョンが含まれるか確認、修正する
 - [ ] coreおよびblogkitのChangeLogに「release L.M.N」のエントリを追加する
 - [ ] 以下のファイルのバージョンをあげてcommitする
   - coreの lib/tdiary/version.rb
   - blogkitの lib/tdiary/blogkit/version.rb
   - contribの lib/tdiary/contrib/version.rb
 - [ ] core / blogkit / contrib / theme に tag を打つ (`git pull --tags; git tag vL.M.N; git push origin vL.M.N`)
+  - coreはtag pushで `.github/workflows/release.yml` が起動し、trusted publishing で gem を rubygems.org に publish、GitHub Release を自動作成する。`.github/workflows/build-image.yml` が Docker イメージも build/push する
+- [ ] coreの [Actions](https://github.com/tdiary/tdiary-core/actions) で Release ワークフローの成功と、rubygems.org / GitHub Release / Docker イメージへの反映を確認する
+- [ ] 自動生成された core の [GitHub Release](https://github.com/tdiary/tdiary-core/releases) のノートを必要に応じて加筆する
 - [ ] 以下の各リポジトリ配下で`bundle clean; bundle exec rake release` コマンドを実行する (gemを最新にしてrubygemsにアップロード)
-  - core
   - blogkit
   - contrib
-- [ ] core配下で`bundle exec rake package:stable package:release` コマンドを実行する(GitHub に tar.gz をアップロードする。GITHUB_ACCESS_TOKEN環境変数が必要なので注意, see #573)
+- [ ] (Phase 2 実装までの暫定) full tarball を GitHub Release に添付する場合は、core配下で `bundle exec rake package:stable` を実行し tmp 配下の tar.gz を手動でアップロードする (`package:release` と GITHUB_ACCESS_TOKEN による自動アップロードは廃止。CI での自動生成・添付は別途対応予定)
 - [ ] themeのmasterブランチをgh-pagesブランチへmerge、pushする (`git checkout gh-pages; git merge master; git push origin gh-pages`)
-- [ ] core配下で `docker build . -t tdiary/tdiary:L.M.N` を実行してから、`push` する (`L.M`, `L`, `latest` も同様)
 - [ ] tdiary.org の以下のエントリーを書く
   - [ダウンロード](https://github.com/tdiary/tdiary.github.io/blob/master/download.md)
   - [サイドバー](https://github.com/tdiary/tdiary.github.io/blob/master/_includes/sidebar.html)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,11 @@ jobs:
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release create "$GITHUB_REF_NAME" --title "tDiary ${GITHUB_REF_NAME#v}" --generate-notes --verify-tag
+      run: |
+        case "$GITHUB_REF_NAME" in
+          *beta*|*rc*) PRERELEASE=--prerelease ;;
+        esac
+        gh release create "$GITHUB_REF_NAME" --title "tDiary ${GITHUB_REF_NAME#v}" --generate-notes --verify-tag $PRERELEASE
 
   package:
     name: Build and attach full tarball

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,25 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh release create "$GITHUB_REF_NAME" --title "tDiary ${GITHUB_REF_NAME#v}" --generate-notes --verify-tag
+
+  package:
+    name: Build and attach full tarball
+    needs: push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ruby
+        bundler-cache: true
+    - name: Build tarballs
+      env:
+        VERSION: ${{ github.ref_name }}
+      run: bundle exec rake package:stable
+    - name: Attach tarballs to the release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload "$GITHUB_REF_NAME" tmp/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  push:
+    name: Push gem to RubyGems.org
+    if: github.repository == 'tdiary/tdiary-core'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ruby
+        bundler-cache: true
+    - name: Publish to RubyGems.org
+      uses: rubygems/release-gem@v1
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release create "$GITHUB_REF_NAME" --title "tDiary ${GITHUB_REF_NAME#v}" --generate-notes --verify-tag

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ group :development do
   gem 'pit', require: false
   gem 'racksh', require: false
   gem 'redcarpet'
-  gem 'octokit'
   gem 'mime-types'
 
   group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,9 +162,6 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0, >= 2.0.7)
       version_gem (~> 1.1, >= 1.1.14)
-    octokit (4.22.0)
-      faraday (>= 0.9)
-      sawyer (~> 0.8.0, >= 0.5.3)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
       logger
@@ -226,9 +223,6 @@ GEM
     rspec-support (3.13.6)
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
-    sawyer (0.8.2)
-      addressable (>= 2.3.5)
-      faraday (> 0.8, < 2.0)
     securerandom (0.4.1)
     selenium-webdriver (4.33.0)
       base64 (~> 0.2)
@@ -326,7 +320,6 @@ DEPENDENCIES
   mail
   memcachier
   mime-types
-  octokit
   omniauth
   omniauth-github
   pit

--- a/lib/tdiary/tasks/release.rake
+++ b/lib/tdiary/tasks/release.rake
@@ -13,6 +13,24 @@ def fetch_files( repo )
 	end
 end
 
+# Check out the release tag in a cloned repo. Sibling repos are not always
+# tagged for core-only patch releases, so fall back to the latest tag of the
+# same minor series, then to the default branch as cloned.
+def checkout_release( repo, version )
+	Dir.chdir repo do
+		tags = `git tag`.split(/\n/)
+		unless tags.include?(version)
+			minor = version[/\Av\d+\.\d+\./]
+			version = tags.grep(/\A#{Regexp.escape(minor)}\d+(\.\d+)*\z/).max_by {|t| Gem::Version.new(t.sub(/\Av/, '')) } if minor
+		end
+		if version && tags.include?(version)
+			sh "git checkout #{version}"
+		else
+			puts "#{repo}: no matching tag, using default branch"
+		end
+	end
+end
+
 # Gems that ship a C extension but also provide a pure-ruby implementation,
 # so we can vendor the .rb files and drop the compiled extension.
 NATIVE_GEMS_WITH_RUBY_FALLBACK = %w(cgi)
@@ -73,11 +91,7 @@ def make_tarball( repo, version = nil )
 	suffix = version ? "-#{version}" : '-snapshot'
 	dest = "#{repo == 'tdiary-core' ? 'tdiary' : repo}#{suffix}"
 
-	if version then
-		Dir.chdir repo do
-			sh "git checkout #{version}"
-		end
-	end
+	checkout_release( repo, version ) if version
 	rm_rf "#{repo}/.git"
 
 	sh "find #{repo} -type f | xargs chmod 644"
@@ -126,9 +140,9 @@ namespace :package do
 		make_full_package
 	end
 
-	desc 'making packages of stable.'
+	desc 'making packages of stable. VERSION=vX.Y.Z overrides the latest tag.'
 	task :stable => :fetch do
-		make_full_package(STABLE)
+		make_full_package(ENV['VERSION'] || STABLE)
 	end
 
 	desc 'cleanup all files.'

--- a/lib/tdiary/tasks/release.rake
+++ b/lib/tdiary/tasks/release.rake
@@ -1,212 +1,143 @@
 #
-# Ralefile for releasing tDiary.
+# Rakefile for building tDiary release tarballs.
 #
-begin
-	require 'octokit'
+STABLE = `git tag | grep -v beta | sort -r -V | head -1`.chomp
+REPOS = %w(tdiary-core tdiary-theme tdiary-blogkit tdiary-contrib)
 
-	STABLE = `git tag | grep -v beta | sort -r -V | head -1`.chomp
-	REPOS = %w(tdiary-core tdiary-theme tdiary-blogkit tdiary-contrib)
+TARBALLS = []
 
-	DEST_DIR = "/var/www/tdiary.org/htdocs/download"
-	TARBALLS = []
+def fetch_files( repo )
+	Dir.chdir("tmp") do
+		rm_rf repo rescue true
+		sh "git clone https://github.com/tdiary/#{repo}.git #{repo}"
+	end
+end
 
-	def fetch_files( repo )
+# Gems that ship a C extension but also provide a pure-ruby implementation,
+# so we can vendor the .rb files and drop the compiled extension.
+NATIVE_GEMS_WITH_RUBY_FALLBACK = %w(cgi)
+
+# Build a self-contained vendor/bundle for the full tarball.
+#
+# Only pure-ruby gems are vendored, into a single flat gem repository
+# (vendor/bundle/{gems,specifications}) that every supported Ruby shares.
+# Native gems are not copied across ABIs: date is a Ruby default gem, and
+# cgi is vendored without its compiled escape extension (pure-ruby fallback).
+def vendor_pure_ruby_gems
+	build_dir = File.expand_path('.vendor-build')
+	vendor = File.expand_path('vendor/bundle')
+	rm_rf build_dir
+	rm_rf vendor
+	mkdir_p "#{vendor}/gems"
+	mkdir_p "#{vendor}/specifications"
+
+	Bundler.with_unbundled_env do
+		ENV['BUNDLE_PATH'] = build_dir
+		ENV['BUNDLE_WITHOUT'] = 'development:test'
+		ENV['BUNDLE_FROZEN'] = 'true'
+		sh 'bundle install'
+	end
+
+	abi = Dir["#{build_dir}/ruby/*"].first
+	Dir["#{abi}/specifications/*.gemspec"].each do |spec_file|
+		spec = Gem::Specification.load(spec_file)
+		next if spec.nil?
+		name_version = "#{spec.name}-#{spec.version}"
+		gem_dir = "#{abi}/gems/#{name_version}"
+		if spec.extensions.empty?
+			cp_r gem_dir, "#{vendor}/gems/#{name_version}"
+			cp spec_file, "#{vendor}/specifications/"
+		elsif NATIVE_GEMS_WITH_RUBY_FALLBACK.include?(spec.name)
+			cp_r gem_dir, "#{vendor}/gems/#{name_version}"
+			spec.extensions.clear
+			File.write("#{vendor}/specifications/#{File.basename(spec_file)}", spec.to_ruby)
+			puts "vendored without native extension: #{name_version}"
+		else
+			puts "skipped native gem (provided at deploy time): #{name_version}"
+		end
+	end
+	rm_rf build_dir
+
+	# reduce filesize: keep only lib/ and data/ in each vendored gem
+	Dir["#{vendor}/gems/*/*/"].each do |dir|
+		rm_rf dir unless %w(lib data).include?(File.basename(dir))
+	end
+
+	# Ship a bundler config that excludes dev/test but sets no path, so
+	# bundler/setup resolves the vendored gems from GEM_PATH at runtime.
+	mkdir_p '.bundle'
+	File.write('.bundle/config', %Q(---\nBUNDLE_WITHOUT: "development:test"\n))
+end
+
+def make_tarball( repo, version = nil )
+	suffix = version ? "-#{version}" : '-snapshot'
+	dest = "#{repo == 'tdiary-core' ? 'tdiary' : repo}#{suffix}"
+
+	if version then
+		Dir.chdir repo do
+			sh "git checkout #{version}"
+		end
+	end
+	rm_rf "#{repo}/.git"
+
+	sh "find #{repo} -type f | xargs chmod 644"
+	sh "find #{repo} -type d | xargs chmod 755"
+
+	if repo == 'tdiary-core' then
+		Dir.chdir 'tdiary-core' do
+			sh "chmod +x index.rb index.fcgi update.rb update.fcgi"
+			sh 'rake doc'
+			vendor_pure_ruby_gems
+		end
+	end
+
+	mv repo, dest
+	sh "tar zcf #{dest}.tar.gz --format=posix #{dest}"
+	mv dest, repo
+	TARBALLS << "#{dest}.tar.gz"
+end
+
+def make_full_package(version = nil)
+	suffix = version ? "-#{version}" : '-snapshot'
+	Dir.chdir("tmp") do
+		TARBALLS.clear
+		REPOS.each do |repo|
+			make_tarball( repo, version )
+		end
+		Dir["tdiary-theme/*"].each do |d|
+			mv d, "tdiary-core/theme/" rescue true
+		end
+		mv "tdiary-core", "tdiary#{suffix}"
+		sh "tar zcf tdiary-full#{suffix}.tar.gz --format=posix tdiary#{suffix}"
+		TARBALLS << "tdiary-full#{suffix}.tar.gz"
+		rm_rf "tdiary#{suffix}"
+		REPOS.each {|repo| rm_rf repo rescue true }
+	end
+end
+
+namespace :package do
+	desc 'fetching all files from GitHub.'
+	task :fetch do
+		REPOS.each{|r| fetch_files(r) }
+	end
+
+	desc 'making packages of snapshot.'
+	task :snapshot => :fetch do
+		make_full_package
+	end
+
+	desc 'making packages of stable.'
+	task :stable => :fetch do
+		make_full_package(STABLE)
+	end
+
+	desc 'cleanup all files.'
+	task :clean do
 		Dir.chdir("tmp") do
-			rm_rf repo rescue true
-			sh "git clone https://github.com/tdiary/#{repo}.git #{repo}"
-		end
-	end
-
-	# Gems that ship a C extension but also provide a pure-ruby implementation,
-	# so we can vendor the .rb files and drop the compiled extension.
-	NATIVE_GEMS_WITH_RUBY_FALLBACK = %w(cgi)
-
-	# Build a self-contained vendor/bundle for the full tarball.
-	#
-	# Only pure-ruby gems are vendored, into a single flat gem repository
-	# (vendor/bundle/{gems,specifications}) that every supported Ruby shares.
-	# Native gems are not copied across ABIs: date is a Ruby default gem, and
-	# cgi is vendored without its compiled escape extension (pure-ruby fallback).
-	def vendor_pure_ruby_gems
-		build_dir = File.expand_path('.vendor-build')
-		vendor = File.expand_path('vendor/bundle')
-		rm_rf build_dir
-		rm_rf vendor
-		mkdir_p "#{vendor}/gems"
-		mkdir_p "#{vendor}/specifications"
-
-		Bundler.with_unbundled_env do
-			ENV['BUNDLE_PATH'] = build_dir
-			ENV['BUNDLE_WITHOUT'] = 'development:test'
-			ENV['BUNDLE_FROZEN'] = 'true'
-			sh 'bundle install'
-		end
-
-		abi = Dir["#{build_dir}/ruby/*"].first
-		Dir["#{abi}/specifications/*.gemspec"].each do |spec_file|
-			spec = Gem::Specification.load(spec_file)
-			next if spec.nil?
-			name_version = "#{spec.name}-#{spec.version}"
-			gem_dir = "#{abi}/gems/#{name_version}"
-			if spec.extensions.empty?
-				cp_r gem_dir, "#{vendor}/gems/#{name_version}"
-				cp spec_file, "#{vendor}/specifications/"
-			elsif NATIVE_GEMS_WITH_RUBY_FALLBACK.include?(spec.name)
-				cp_r gem_dir, "#{vendor}/gems/#{name_version}"
-				spec.extensions.clear
-				File.write("#{vendor}/specifications/#{File.basename(spec_file)}", spec.to_ruby)
-				puts "vendored without native extension: #{name_version}"
-			else
-				puts "skipped native gem (provided at deploy time): #{name_version}"
-			end
-		end
-		rm_rf build_dir
-
-		# reduce filesize: keep only lib/ and data/ in each vendored gem
-		Dir["#{vendor}/gems/*/*/"].each do |dir|
-			rm_rf dir unless %w(lib data).include?(File.basename(dir))
-		end
-
-		# Ship a bundler config that excludes dev/test but sets no path, so
-		# bundler/setup resolves the vendored gems from GEM_PATH at runtime.
-		mkdir_p '.bundle'
-		File.write('.bundle/config', %Q(---\nBUNDLE_WITHOUT: "development:test"\n))
-	end
-
-	def make_tarball( repo, version = nil )
-		suffix = version ? "-#{version}" : '-snapshot'
-		dest = "#{repo == 'tdiary-core' ? 'tdiary' : repo}#{suffix}"
-
-		if version then
-			Dir.chdir repo do
-				sh "git checkout #{version}"
-			end
-		end
-		rm_rf "#{repo}/.git"
-
-		sh "find #{repo} -type f | xargs chmod 644"
-		sh "find #{repo} -type d | xargs chmod 755"
-
-		if repo == 'tdiary-core' then
-			Dir.chdir 'tdiary-core' do
-				sh "chmod +x index.rb index.fcgi update.rb update.fcgi"
-				sh 'rake doc'
-				vendor_pure_ruby_gems
-			end
-		end
-
-		mv repo, dest
-		sh "tar zcf #{dest}.tar.gz --format=posix #{dest}"
-		mv dest, repo
-		TARBALLS << "#{dest}.tar.gz"
-	end
-
-	def make_full_package(version = nil)
-		suffix = version ? "-#{version}" : '-snapshot'
-		Dir.chdir("tmp") do
-			TARBALLS.clear
-			REPOS.each do |repo|
-				make_tarball( repo, version )
-			end
-			Dir["tdiary-theme/*"].each do |d|
-				mv d, "tdiary-core/theme/" rescue true
-			end
-			mv "tdiary-core", "tdiary#{suffix}"
-			sh "tar zcf tdiary-full#{suffix}.tar.gz --format=posix tdiary#{suffix}"
-			TARBALLS << "tdiary-full#{suffix}.tar.gz"
-			rm_rf "tdiary#{suffix}"
 			REPOS.each {|repo| rm_rf repo rescue true }
+			sh "rm *.tar.gz" rescue true
 		end
 	end
-
-	#
-	# https://developer.github.com/v3/repos/releases/#create-a-release
-	#
-	def create_github_release(version)
-		name = "tDiary #{version.sub(/v/, '')}"
-		puts "creating github release #{version}, #{name}"
-		begin
-			Octokit.create_release('tdiary/tdiary-core', version, name: name)
-		rescue Octokit::ClientError => e
-			STDERR.puts e
-		end
-	end
-
-	#
-	# https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
-	#
-	def find_or_create_github_release(version)
-		begin
-			release = Octokit.release_for_tag('tdiary/tdiary-core', version)
-		rescue Octokit::NotFound
-			release = create_github_release(version)
-		end
-		release
-	end
-
-	#
-	# https://developer.github.com/v3/repos/releases/#upload-a-release-asset
-	#
-	def upload_github_asset(release, file)
-		puts "updating file to github: #{file}"
-		begin
-			Octokit.upload_asset(release.url, file)
-		rescue Octokit::ClientError => e
-			STDERR.puts e
-		end
-	end
-
-	#
-	# https://developer.github.com/v3/#authentication
-	#
-	def login_github
-		unless ENV['GITHUB_ACCESS_TOKEN']
-			raise "Missing $GITHUB_ACCESS_TOKEN environment.\nSee: https://help.github.com/articles/creating-an-access-token-for-command-line-use/"
-		end
-		Octokit.configure {|c| c.access_token = ENV['GITHUB_ACCESS_TOKEN'] }
-		Octokit.auto_paginate = true
-	end
-
-	namespace :package do
-		desc 'fetching all files from GitHub.'
-		task :fetch do
-			REPOS.each{|r| fetch_files(r) }
-		end
-
-		desc 'releasing all files'
-		task :release do
-			login_github
-			Dir.chdir("tmp") do
-				TARBALLS = Dir["*.tar.gz"] if TARBALLS.empty?
-				TARBALLS.each do |tgz|
-					# TODO: v5.0.0.20160501 形式のバージョンに対応させる
-					version = tgz.match(/v?\d\.\d\.\d/).to_a[0]
-					next unless version
-					release = find_or_create_github_release(version)
-					upload_github_asset(release, tgz)
-				end
-			end
-		end
-
-		desc 'making packages of snapshot.'
-		task :snapshot => :fetch do
-			make_full_package
-		end
-
-		desc 'making packages of stable.'
-		task :stable => :fetch do
-			make_full_package(STABLE)
-		end
-
-		desc 'cleanup all files.'
-		task :clean do
-			Dir.chdir("tmp") do
-				REPOS.each {|repo| rm_rf repo rescue true }
-				sh "rm *.tar.gz" rescue true
-			end
-		end
-	end
-rescue LoadError
 end
 
 # Local Variables:

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = "5.4.0"
+	VERSION = "5.5.0.beta1"
 end


### PR DESCRIPTION
Pushing a `v*` tag now runs `.github/workflows/release.yml`, which builds and publishes the gem to rubygems.org through `rubygems/release-gem` with OIDC trusted publishing, then creates the GitHub Release with generated notes. Maintainers no longer need local API keys for `gem push`.

The octokit-based `package:release` upload task is removed along with the `octokit` dependency. The tarball build tasks (`package:fetch`, `package:snapshot`, `package:stable`, `package:clean`) remain for the download distribution and will move to CI separately. The release checklist is updated for the tag-driven flow.

Before the first tag release, the trusted publisher for the `tdiary` gem must be registered on rubygems.org with workflow `release.yml` and environment `release`, and the `release` environment must exist in the repository settings.
