### PR TITLE
Align the editor textarea with the fields above it

### DIFF
--- a/theme/base.css
+++ b/theme/base.css
@@ -286,13 +286,14 @@ div.youtube-player-wrapper {
 /*
  * editor textarea sizing
  *
- * Widen the editor 10% past the form column, splitting the overflow
- * evenly on both sides so it stays centered with the fields around it.
+ * The inline margins are zeroed on purpose: themes indent textareas
+ * (tdiary2 uses margin-left: 3em), which would push the editor out of
+ * line with the fields above it.
  */
 textarea#body {
 	box-sizing: border-box;
-	width: 110%;
-	margin-inline: -5%;
+	width: 100%;
+	margin-inline: 0;
 	height: clamp(10rem, 33dvh, 33rem);
 	resize: vertical;
 }


### PR DESCRIPTION
The editor textarea hung 5% past the left edge of the labels above it and pushed its right edge off the viewport, which forced a horizontal scrollbar on the update page.

`textarea#body` in `theme/base.css` is an ID selector, so it outranks the `margin-left` that themes set on `form.update textarea` (`tdiary2` uses `3em`). The negative inline margins added in 858bb0bd therefore cancelled the theme indent and pulled the editor out of line instead of centering it. Zeroing the inline margins and dropping back to `width: 100%` lines the left edge up with the subtitle, the title field and the body label, and keeps the right edge inside the form column. Widening past the column is not viable here because the wrapper is already the full form width, so any overflow lands outside the viewport.

Measured on a 1280px viewport with the `tdiary2` theme. Before the fix the labels sat at 77px while the textarea started at 18.3px and ran to 1309.7px, giving a 1310px scroll width. After the fix the textarea spans 77px to 1251px, matching the labels and the form column with no horizontal overflow. The `default` theme lines up at 206px in the same way. The height from 858bb0bd is unchanged.
