### PR TITLE
Introduce TDiary::CGICompat, a CGI facade over TDiary::Request

### DIFF
--- a/lib/tdiary.rb
+++ b/lib/tdiary.rb
@@ -57,6 +57,8 @@ module TDiary
 	# Rack Request and Reponse, If you don't use Rack, adopt Rack interface.
 	autoload :Request,                  'tdiary/request'
 	autoload :Response,                 'tdiary/response'
+	# CGI compatible facade over TDiary::Request, passed to plugins as @cgi
+	autoload :CGICompat,                'tdiary/cgi_compat'
 
 	# ViewController created by Dispatcher
 	autoload :TDiaryBase,               'tdiary/base'

--- a/lib/tdiary/cgi_compat.rb
+++ b/lib/tdiary/cgi_compat.rb
@@ -1,0 +1,172 @@
+module TDiary
+	#
+	# class CGICompat
+	#  provides the CGI compatible interface consumed by plugins as @cgi on
+	#  top of TDiary::Request. Behaviour is locked by the shared examples in
+	#  spec/support/cgi_compat_shared_examples.rb, which are also applied to
+	#  RackCGI. Not wired into the dispatcher yet.
+	#
+	class CGICompat
+		include TDiary::RequestExtension
+
+		attr_reader :request
+
+		def initialize( request )
+			@request = request
+			# built eagerly so that a clone (Object#clone copies instance
+			# variables by reference) shares the same params Hash, like a
+			# cloned CGI instance does. 00default.rb relies on this.
+			@params = build_params
+		end
+
+		attr_reader :params
+
+		def valid?( param, idx = 0 )
+			params[param] and params[param][idx] and params[param][idx].length > 0
+		end
+
+		def cookies
+			# CGI::Cookie keeps the multi-value cookie behaviour (00default.rb
+			# reads name and mail from the two values of the tdiary cookie)
+			@cookies ||= CGI::Cookie.parse( env_table['HTTP_COOKIE'] )
+		end
+
+		def env_table
+			@request.env
+		end
+
+		def referer
+			env_table['HTTP_REFERER']
+		end
+
+		def user_agent
+			env_table['HTTP_USER_AGENT']
+		end
+
+		def remote_addr
+			env_table['REMOTE_ADDR']
+		end
+
+		def request_method
+			env_table['REQUEST_METHOD']
+		end
+
+		def script_name
+			env_table['SCRIPT_NAME']
+		end
+
+		def remote_user
+			env_table['REMOTE_USER']
+		end
+
+		def auth_type
+			env_table['AUTH_TYPE']
+		end
+
+		def gateway_interface
+			env_table['GATEWAY_INTERFACE']
+		end
+
+		def server_name
+			env_table['SERVER_NAME']
+		end
+
+		def server_port
+			env_table['SERVER_PORT'].to_i
+		end
+
+		# the URL helpers below duplicate the CGI patches in core_ext.rb,
+		# which stay there for standalone scripts (misc/migrate.rb etc.)
+		def https?
+			return true if env_table['HTTP_X_FORWARDED_PROTO'] == 'https'
+			return false if env_table['HTTPS'].nil? or /off/i =~ env_table['HTTPS'] or env_table['HTTPS'] == ''
+			true
+		end
+
+		def request_uri
+			_request_uri = env_table['REQUEST_URI']
+			_script_name = env_table['SCRIPT_NAME']
+			if !_request_uri || _request_uri == '' || _request_uri == _script_name then
+				_path_info    = env_table['PATH_INFO'] || ''
+				_query_string = env_table['QUERY_STRING'] || ''
+				# Workaround for IIS-style PATH_INFO ('/dir/script.cgi/path', not '/path')
+				# See http://support.microsoft.com/kb/184320/
+				_request_uri = _path_info.include?(_script_name) ? '' : _script_name.dup
+				_request_uri << _path_info
+				_request_uri << '?' + _query_string if _query_string != ''
+			end
+			_request_uri
+		end
+
+		def redirect_url
+			env_table['REDIRECT_URL']
+		end
+
+		def base_url
+			return '' unless script_name
+			begin
+				script_dirname = script_name.empty? ? '' : File::dirname(script_name)
+				if https?
+					port = (server_port == 443) ? '' : ':' + server_port.to_s
+					"https://#{server_name}#{port}#{script_dirname}/"
+				else
+					port = (server_port == 80) ? '' : ':' + server_port.to_s
+					"http://#{server_name}#{port}#{script_dirname}/"
+				end.sub(%r|/+$|, '/')
+			rescue SecurityError
+				''
+			end
+		end
+
+	private
+
+		def build_params
+			source =
+				if request_method == 'POST'
+					if %r|\Amultipart/form-data|.match?( env_table['CONTENT_TYPE'].to_s )
+						@request.POST
+					else
+						# Rack's nested query parser behind request.POST keeps only
+						# the last of duplicated keys; CGI collects all of them
+						::Rack::Utils.parse_query( read_raw_body )
+					end
+				else
+					::Rack::Utils.parse_query( env_table['QUERY_STRING'].to_s )
+				end
+
+			params = {}
+			source.each do |key, value|
+				values = value.kind_of?( Array ) ? value : [value]
+				params[key] = values.map {|v| normalize_value( v ) }
+			end
+			params.default = []
+			params
+		end
+
+		def read_raw_body
+			input = env_table['rack.input']
+			return '' unless input
+			body = input.read
+			input.rewind if input.respond_to?( :rewind )
+			body || ''
+		end
+
+		def normalize_value( value )
+			if value.kind_of?( Hash ) and value[:tempfile]
+				# Rack multipart file upload: expose an object responding to
+				# read, which is all the consumers use
+				value[:tempfile]
+			else
+				value.to_s
+			end
+		end
+	end
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:
+# vim: ts=3

--- a/lib/tdiary/cgi_compat.rb
+++ b/lib/tdiary/cgi_compat.rb
@@ -157,7 +157,21 @@ module TDiary
 				# read, which is all the consumers use
 				value[:tempfile]
 			else
-				value.to_s
+				repair_encoding( value.to_s )
+			end
+		end
+
+		# CGI/FCGI hosting retries broken UTF-8 input as Shift_JIS (index.rb,
+		# misc/lib/fcgi_patch.rb). The facade implements the same fallback on
+		# each value: invalid UTF-8 is converted from Shift_JIS when possible,
+		# otherwise scrubbed.
+		def repair_encoding( str )
+			str = str.dup.force_encoding( Encoding::UTF_8 ) unless str.encoding == Encoding::UTF_8
+			return str if str.valid_encoding?
+			begin
+				str.dup.force_encoding( Encoding::Shift_JIS ).encode( Encoding::UTF_8 )
+			rescue EncodingError
+				str.scrub
 			end
 		end
 	end

--- a/spec/core/cgi_compat_spec.rb
+++ b/spec/core/cgi_compat_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'stringio'
+require 'rack'
+require 'support/cgi_compat_shared_examples'
+
+describe TDiary::CGICompat do
+	def build_cgi(env, body: nil)
+		rack_env = Rack::MockRequest.env_for('http://www.example.com/')
+		rack_env.merge!(env)
+		if body
+			rack_env['CONTENT_LENGTH'] = body.bytesize.to_s
+			rack_env['rack.input'] = StringIO.new(body)
+		end
+		TDiary::CGICompat.new(TDiary::Request.new(rack_env))
+	end
+
+	it_behaves_like 'CGI compatible request facade'
+
+	it 'exposes the wrapped request' do
+		cgi = build_cgi({ 'REQUEST_METHOD' => 'GET', 'QUERY_STRING' => '' })
+		expect(cgi.request).to be_a(TDiary::Request)
+	end
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:
+# vim: ts=3

--- a/spec/core/cgi_compat_spec.rb
+++ b/spec/core/cgi_compat_spec.rb
@@ -20,6 +20,35 @@ describe TDiary::CGICompat do
 		cgi = build_cgi({ 'REQUEST_METHOD' => 'GET', 'QUERY_STRING' => '' })
 		expect(cgi.request).to be_a(TDiary::Request)
 	end
+
+	describe 'Shift_JIS fallback' do
+		it 'converts a Shift_JIS query value to UTF-8' do
+			sjis = 'こんにちは'.encode(Encoding::Shift_JIS)
+			cgi = build_cgi({ 'REQUEST_METHOD' => 'GET', 'QUERY_STRING' => "greeting=#{CGI.escape(sjis.b)}" })
+			expect(cgi.params['greeting']).to eq ['こんにちは']
+			expect(cgi.params['greeting'][0].encoding).to eq Encoding::UTF_8
+		end
+
+		it 'converts a Shift_JIS body value to UTF-8' do
+			sjis = 'さようなら'.encode(Encoding::Shift_JIS)
+			cgi = build_cgi(
+				{
+					'REQUEST_METHOD' => 'POST',
+					'CONTENT_TYPE' => 'application/x-www-form-urlencoded'
+				},
+				body: "message=#{CGI.escape(sjis.b)}"
+			)
+			expect(cgi.params['message']).to eq ['さようなら']
+		end
+
+		it 'scrubs a value that is neither valid UTF-8 nor Shift_JIS' do
+			cgi = build_cgi({ 'REQUEST_METHOD' => 'GET', 'QUERY_STRING' => 'broken=%FF%FE%FF' })
+			value = cgi.params['broken'][0]
+			expect(value.encoding).to eq Encoding::UTF_8
+			expect(value.valid_encoding?).to be true
+			expect(value).to include("�")
+		end
+	end
 end
 
 # Local Variables:


### PR DESCRIPTION
Phase 1 of removing the fake-CGI instance passing. All Phase 0 behaviour-lock PRs (#1330, #1331, #1333 to #1337) are merged, so this is now rebased onto `master` and adds a single commit. `TDiary::CGICompat` wraps a `TDiary::Request` and implements the whole `@cgi` surface fixed by the shared examples from #1331, which are applied to it unchanged, so equivalence with `RackCGI` is proven by the same spec. As a new behaviour, each param value that is not valid UTF-8 is retried as Shift_JIS and converted, falling back to `String#scrub`. This replaces the process-global re-parse done by `index.rb` and `misc/lib/fcgi_patch.rb` and becomes load-bearing in phase 3. Production behaviour is unchanged. The only touch to existing code is one `autoload` line in `lib/tdiary.rb`, and wiring the dispatcher to it is phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
