### PR TITLE
Add acceptance spec for comment cookie round-trip

### DIFF
--- a/spec/acceptance/comment_cookie_spec.rb
+++ b/spec/acceptance/comment_cookie_spec.rb
@@ -1,0 +1,33 @@
+require 'acceptance_helper'
+
+feature 'ツッコミ後のcookie' do
+	# The comment is posted via /index.rb, not via the form on /. With the
+	# form the tdiary cookie is issued with "path=./" (derived from the empty
+	# SCRIPT_NAME); browsers fall back to the default-path and restore it,
+	# but the strict rack-test cookie jar drops such a cookie.
+	scenario '次回のコメントフォームにnameとmailが補完される', :exclude_selenium do
+		append_default_diary
+		today = Date.today.strftime('%Y%m%d')
+
+		page.driver.post '/index.rb', {
+			'date' => today,
+			'name' => 'アリス',
+			'mail' => 'alice@example.com',
+			'body' => 'こんにちは!こんにちは!',
+			'comment' => 'comment'
+		}
+		expect(page).to have_content "Click here!"
+
+		visit "/?date=#{today}"
+		expect(page.find('input[name=name]').value).to eq "アリス"
+		expect(page.find('input[name=mail]').value).to eq "alice@example.com"
+	end
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:
+# vim: ts=3


### PR DESCRIPTION
Adds an acceptance spec that locks the comment cookie behavior: after posting a comment, `name` and `mail` are restored into the next comment form. This continues the Phase 0 behavior-lock tests started in #1331, ahead of the `@cgi` removal work.

The comment is posted via `page.driver.post '/index.rb'` instead of the form on `/`. With an empty `SCRIPT_NAME` the tdiary cookie is issued with `path=./`, which real browsers accept via the default-path fallback but the strict rack-test cookie jar drops. The rationale is documented in the spec file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)