### PR TITLE
Add pstore as a runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'emot'
 gem 'mail'
 gem 'rake'
 gem 'cgi'
+gem 'pstore'
 
 group :development do
   gem 'pit', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       sawyer (~> 0.9)
     pit (0.0.7)
     power_assert (3.0.1)
+    pstore (0.2.1)
     public_suffix (6.0.2)
     racc (1.8.1)
     rack (3.2.6)
@@ -163,6 +164,7 @@ PLATFORMS
   arm-linux-musl
   arm64-darwin
   ruby
+  x64-mswin64-140
   x86-linux
   x86-linux-gnu
   x86-linux-musl
@@ -183,6 +185,7 @@ DEPENDENCIES
   mime-types
   octokit
   pit
+  pstore
   rack
   rack-session
   racksh

--- a/tdiary.gemspec
+++ b/tdiary.gemspec
@@ -45,4 +45,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rexml'
   spec.add_dependency 'cgi'
   spec.add_dependency 'webrick'
+  spec.add_dependency 'pstore'
 end


### PR DESCRIPTION
Ruby 4.0 moves pstore from default gems to bundled gems, so `require 'pstore'` in `lib/tdiary.rb` (and the pstore-based IO classes) raises `LoadError` on a plain Ruby 4.0 install. This declares `pstore` in the gemspec and Gemfile like the existing `cgi` and `webrick` dependencies. On Ruby 3.1-3.4, where pstore is still a default gem, this is a no-op. Verified with `bundle exec rake spec` on Ruby 4.0.5 (261 examples, 0 failures).