### PR TITLE
Add acceptance spec for assets URLs under Rack hosting

### DIFF
--- a/spec/acceptance/view_diary_spec.rb
+++ b/spec/acceptance/view_diary_spec.rb
@@ -10,6 +10,18 @@ feature '日記を読む' do
 		expect(page).to have_css('a[href="update.rb?conf=default"]')
 	end
 
+	scenario 'RackアプリではCSSとJavaScriptがassets配下から配信される', :exclude_selenium do
+		visit '/'
+		stylesheet_hrefs = page.all('link[rel=stylesheet]', visible: false).map {|link| link[:href] }
+		expect(stylesheet_hrefs).not_to be_empty
+		expect(stylesheet_hrefs).to all( start_with 'assets/' )
+
+		script_srcs = page.all('script[src]', visible: false).map {|script| script[:src] }
+		local_script_srcs = script_srcs.reject {|src| src.start_with?('http', '//') }
+		expect(local_script_srcs).not_to be_empty
+		expect(local_script_srcs).to all( start_with 'assets/' )
+	end
+
 	scenario '月またぎの日記の表示' do
 		append_default_diary('20100430')
 		append_default_diary('20100501')


### PR DESCRIPTION
Part of the Phase 0 behavior-locking specs (following #1331 and #1333) for the `@cgi` removal work.

Adds one acceptance scenario asserting that under Rack hosting all stylesheet `href`s and local script `src`s start with `assets/`. This locks the `RackCGI` side of the `js_url`/`theme_url` branch in `plugin/00default.rb`, so a later phase can prove equivalence when `RackCGI` is replaced by a compat facade. The CGI-hosted side (`theme/` and `js/`) will be covered by a separate CGI smoke spec.

No production code changes.