### PR TITLE
Add smoke spec running index.rb as a plain CGI process

### DIFF
--- a/spec/core/cgi_endpoint_smoke_spec.rb
+++ b/spec/core/cgi_endpoint_smoke_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+# Smoke test running index.rb as a real CGI process, locking the plain CGI
+# hosting path (no Rack, @cgi is a plain CGI instance).
+describe 'index.rb as a plain CGI program' do
+	before(:all) do
+		repo_root = File.expand_path('../../..', __FILE__)
+		@workdir = Dir.mktmpdir('tdiary-cgi-smoke')
+		data_dir = File.join(@workdir, 'tmp/data')
+		FileUtils.mkdir_p data_dir
+		# tdiary.conf.webrick resolves @data_path against the working directory
+		FileUtils.cp File.join(repo_root, 'spec/fixtures/tdiary.conf.webrick'), File.join(@workdir, 'tdiary.conf')
+		FileUtils.cp File.join(repo_root, 'spec/fixtures/just_installed.conf'), File.join(data_dir, 'tdiary.conf')
+
+		env = {
+			'GATEWAY_INTERFACE' => 'CGI/1.1',
+			'REQUEST_METHOD' => 'GET',
+			'QUERY_STRING' => '',
+			'SCRIPT_NAME' => '/index.rb',
+			'SERVER_NAME' => 'www.example.com',
+			'SERVER_PORT' => '80',
+			'HTTP_HOST' => 'www.example.com',
+			'SERVER_PROTOCOL' => 'HTTP/1.1',
+			'REMOTE_ADDR' => '127.0.0.1'
+		}
+		stdout, @stderr, @process_status = Open3.capture3(env, RbConfig.ruby, File.join(repo_root, 'index.rb'), chdir: @workdir)
+		@head, _separator, @body = stdout.partition(/\r?\n\r?\n/)
+	end
+
+	after(:all) do
+		FileUtils.remove_entry @workdir
+	end
+
+	it 'responds with Status 200 and an HTML body' do
+		expect(@head).to match(/^Status: 200/), -> { "head: #{@head.inspect}\nstderr: #{@stderr}" }
+		expect(@body).to include('<html')
+	end
+
+	it 'links css under theme/ and scripts under js/' do
+		expect(@body).to match(%r|<link rel="stylesheet" href="theme/base\.css"|)
+		expect(@body).to match(%r|<script src="js/00default\.js|)
+	end
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:
+# vim: ts=3


### PR DESCRIPTION
This continues the Phase 0 behavior-lock specs (#1331, #1333) ahead of rewriting `index.rb` on `Rackup::Handler::CGI`. The new spec launches `index.rb` as a real CGI process with `Open3.capture3` in a scratch directory and asserts a `Status: 200` HTML response, plus css under `theme/` and scripts under `js/` to lock the CGI-hosting side of the asset URL branch in `00default.rb`. No production code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)