### PR TITLE
Add tdiary.cgi_hosting env flag to select the @cgi facade class

### DIFF
--- a/lib/tdiary/request.rb
+++ b/lib/tdiary/request.rb
@@ -11,9 +11,17 @@ module TDiary
 		end
 
 		# the @cgi object handed to plugins: the real CGI instance under
-		# CGI/FCGI hosting, otherwise a RackCGI facade over this request
+		# CGI/FCGI hosting, otherwise a facade over this request. Endpoints
+		# behind a web server (CGI/FCGI) set tdiary.cgi_hosting in the env to
+		# get the base CGICompat, so @cgi.is_a?(RackCGI) is false and plugins
+		# keep the static js/theme URLs served by the web server.
 		def cgi_compat
-			@cgi || (@cgi_compat ||= ::RackCGI.new( self ))
+			@cgi || (@cgi_compat ||=
+				if @env['tdiary.cgi_hosting']
+					TDiary::CGICompat.new( self )
+				else
+					::RackCGI.new( self )
+				end)
 		end
 
 		def params

--- a/spec/core/request_spec.rb
+++ b/spec/core/request_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'rack'
+
+describe TDiary::Request do
+	describe '#cgi_compat' do
+		def build_request(env = {}, cgi = nil)
+			rack_env = Rack::MockRequest.env_for('http://www.example.com/')
+			rack_env.merge!(env)
+			TDiary::Request.new(rack_env, cgi)
+		end
+
+		it 'returns a RackCGI facade on the Rack path' do
+			expect(build_request.cgi_compat).to be_a(RackCGI)
+		end
+
+		it 'returns the base CGICompat facade when tdiary.cgi_hosting is set' do
+			cgi_compat = build_request('tdiary.cgi_hosting' => true).cgi_compat
+			expect(cgi_compat).to be_a(TDiary::CGICompat)
+			expect(cgi_compat).not_to be_a(RackCGI)
+		end
+
+		it 'is memoized on the request' do
+			request = build_request('tdiary.cgi_hosting' => true)
+			expect(request.cgi_compat).to equal(request.cgi_compat)
+		end
+
+		it 'prefers a real CGI instance regardless of the flag' do
+			real_cgi = Object.new
+			expect(build_request({}, real_cgi).cgi_compat).to equal(real_cgi)
+			expect(build_request({ 'tdiary.cgi_hosting' => true }, real_cgi).cgi_compat).to equal(real_cgi)
+		end
+	end
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:
+# vim: ts=3


### PR DESCRIPTION
Introduces the `tdiary.cgi_hosting` Rack env flag. When it is set, `TDiary::Request#cgi_compat` returns the base `TDiary::CGICompat` facade instead of `RackCGI`, so `@cgi.is_a?(RackCGI)` is false and `00default.rb` keeps pointing plugins at the static `js/` and `theme/` URLs served by the web server. Without the flag the Rack path gets `RackCGI` as before, and a real CGI instance passed to the request always wins.

Nothing sets the flag yet, so there is no behavior change. The consumers arrive in follow-up PRs that rewrite the FCGI and CGI endpoints as thin Rack adapters. Class selection is covered by a new unit spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)