### PR TITLE
Wrap Rack apps in specs with Rack::Lint

### DIFF
--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -3,16 +3,20 @@ require 'spec_helper'
 Dir["#{File.dirname(__FILE__)}/acceptance/support/**/*.rb"].each {|f| require f}
 
 require 'tdiary/application'
+require 'rack/lint'
 Capybara.app = Rack::Builder.new do
 	map '/' do
+		use Rack::Lint
 		run TDiary::Dispatcher.index
 	end
 
 	map '/index.rb' do
+		use Rack::Lint
 		run TDiary::Dispatcher.index
 	end
 
 	map '/update.rb' do
+		use Rack::Lint
 		run TDiary::Dispatcher.update
 	end
 end

--- a/spec/core/application_spec.rb
+++ b/spec/core/application_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'rack/test'
+require 'rack/lint'
 require 'tdiary/application'
 
 describe TDiary::Application do
@@ -9,7 +10,7 @@ describe TDiary::Application do
 	end
 
 	describe '#call' do
-		let(:app) { TDiary::Application.new }
+		let(:app) { Rack::Lint.new(TDiary::Application.new) }
 
 		context "when is accessed to index"
 		it do
@@ -33,7 +34,7 @@ describe TDiary::Application do
 				TDiary.configuration.options['base_url'] = ''
 			end
 
-			let(:app) { TDiary::Application.new }
+			let(:app) { Rack::Lint.new(TDiary::Application.new) }
 
 			it do
 				get '/diary/'

--- a/spec/core/dispatcher_spec.rb
+++ b/spec/core/dispatcher_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'rack/test'
+require 'rack/lint'
 require 'tdiary/application'
 
 describe TDiary::Dispatcher do
@@ -7,6 +8,7 @@ describe TDiary::Dispatcher do
 
 	let(:app) do
 		Rack::Builder.new do
+			use Rack::Lint
 			run TDiary::Dispatcher.index
 		end
 	end

--- a/spec/core/update_multipart_spec.rb
+++ b/spec/core/update_multipart_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'rack/test'
+require 'rack/lint'
 require 'tdiary/application'
 
 # Locks the multipart form-data POST behaviour of the Rack update path,
@@ -10,10 +11,12 @@ describe 'multipart POST to the update dispatcher' do
 	def app
 		@app ||= Rack::Builder.new do
 			map '/' do
+				use Rack::Lint
 				run TDiary::Dispatcher.index
 			end
 
 			map '/update.rb' do
+				use Rack::Lint
 				run TDiary::Dispatcher.update
 			end
 		end


### PR DESCRIPTION
Follow-up to #1342. This wraps every Rack app the spec suite builds with `Rack::Lint`: the `Capybara.app` builder in `spec/acceptance_helper.rb`, the `Rack::Builder` apps in `spec/core/dispatcher_spec.rb` and `spec/core/update_multipart_spec.rb`, and `TDiary::Application` in `spec/core/application_spec.rb` (wrapped from outside so the application itself stays untouched). The CGI smoke spec runs real processes and is out of scope.

With this in place, any Rack SPEC violation introduced by the upcoming response generation rework will fail the suite immediately. Lint found no violations in the current code, so no production change is included. Note that the `charset` pseudo header is lexically a valid header name and passes Lint; removing it is a separate planned task.

Full suite is green with 336 examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
