### PR TITLE
Close the @cgi facade acceptance in view and filter constructors

### DIFF
--- a/lib/tdiary/admin.rb
+++ b/lib/tdiary/admin.rb
@@ -107,8 +107,8 @@ module TDiary
 	#
 	class TDiaryUpdate < TDiaryAdmin
 		def initialize( request, rhtml, conf )
-			# @cgi is not derived yet before super; peel the facade off here
-			params = request.respond_to?( :cgi_compat ) ? request.cgi_compat.params : request.params
+			# @cgi is not derived yet before super; go through the facade here
+			params = request.cgi_compat.params
 			@title = params['title'][0]
 			@body = params['body'][0]
 			@title = conf.to_native( @title )

--- a/lib/tdiary/base.rb
+++ b/lib/tdiary/base.rb
@@ -17,15 +17,9 @@ module TDiary
 		attr_reader :ignore_parser_cache
 
 		def initialize( request, rhtml, conf )
-			if request.respond_to?( :cgi_compat )
-				@request = request
-				@cgi = request.cgi_compat
-			else
-				# transitional: 00default.rb's month navigation hands a cloned
-				# @cgi facade with rewritten params, which must stay @cgi as-is
-				@cgi = request
-				@request = request.respond_to?( :request ) ? request.request : nil
-			end
+			@request = request
+			# plugins read the request through the @cgi facade
+			@cgi = request.cgi_compat
 			@rhtml, @conf = rhtml, conf
 			@diaries = {}
 			@cookies = []

--- a/lib/tdiary/cgi_compat.rb
+++ b/lib/tdiary/cgi_compat.rb
@@ -15,7 +15,7 @@ module TDiary
 			@request = request
 			# built eagerly so that a clone (Object#clone copies instance
 			# variables by reference) shares the same params Hash, like a
-			# cloned CGI instance does. 00default.rb relies on this.
+			# cloned CGI instance does. Plugins may still rely on this.
 			@params = build_params
 		end
 

--- a/lib/tdiary/cgi_compat.rb
+++ b/lib/tdiary/cgi_compat.rb
@@ -75,8 +75,8 @@ module TDiary
 			env_table['SERVER_PORT'].to_i
 		end
 
-		# the URL helpers below duplicate the CGI patches in core_ext.rb,
-		# which stay there for standalone scripts (misc/migrate.rb etc.)
+		# the URL helpers below come from the CGI patches that used to live
+		# in core_ext.rb
 		def https?
 			return true if env_table['HTTP_X_FORWARDED_PROTO'] == 'https'
 			return false if env_table['HTTPS'].nil? or /off/i =~ env_table['HTTPS'] or env_table['HTTPS'] == ''

--- a/lib/tdiary/core_ext.rb
+++ b/lib/tdiary/core_ext.rb
@@ -51,59 +51,6 @@ class String
 	end
 end
 
-=begin
-== CGI class
-enhanced CGI class
-=end
-class CGI
-	include TDiary::RequestExtension
-
-	def valid?( param, idx = 0 )
-		self.params[param] and self.params[param][idx] and self.params[param][idx].length > 0
-	end
-
-	def https?
-		return true if env_table['HTTP_X_FORWARDED_PROTO'] == 'https'
-		return false if env_table['HTTPS'].nil? or /off/i =~ env_table['HTTPS'] or env_table['HTTPS'] == ''
-		true
-	end
-
-	def request_uri
-		_request_uri = env_table['REQUEST_URI']
-		_script_name = env_table['SCRIPT_NAME']
-		if !_request_uri || _request_uri == '' || _request_uri == _script_name then
-			_path_info    = env_table['PATH_INFO'] || ''
-			_query_string = env_table['QUERY_STRING'] || ''
-			# Workaround for IIS-style PATH_INFO ('/dir/script.cgi/path', not '/path')
-			# See http://support.microsoft.com/kb/184320/
-			_request_uri = _path_info.include?(_script_name) ? '' : _script_name.dup
-			_request_uri << _path_info
-			_request_uri << '?' + _query_string if _query_string != ''
-		end
-		_request_uri
-	end
-
-	def redirect_url
-		env_table['REDIRECT_URL']
-	end
-
-	def base_url
-		return '' unless script_name
-		begin
-			script_dirname = script_name.empty? ? '' : File::dirname(script_name)
-			if https?
-				port = (server_port == 443) ? '' : ':' + server_port.to_s
-				"https://#{server_name}#{port}#{script_dirname}/"
-			else
-				port = (server_port == 80) ? '' : ':' + server_port.to_s
-				"http://#{server_name}#{port}#{script_dirname}/"
-			end.sub(%r|/+$|, '/')
-		rescue SecurityError
-			''
-		end
-	end
-end
-
 require 'tdiary/cgi_compat'
 
 # the @cgi facade for Rack-hosted requests. Kept as a toplevel constant

--- a/lib/tdiary/filter.rb
+++ b/lib/tdiary/filter.rb
@@ -11,16 +11,9 @@ module TDiary
 			DEBUG_FULL = 2
 
 			def initialize( request, conf )
-				if request.respond_to?( :cgi_compat )
-					@request = request
-					# filter subclasses read the request through the @cgi facade
-					@cgi = request.cgi_compat
-				else
-					# transitional: 60sf.rb constructs spam filters with the
-					# @cgi facade handed to plugins
-					@cgi = request
-					@request = request.respond_to?( :request ) ? request.request : nil
-				end
+				@request = request
+				# filter subclasses read the request through the @cgi facade
+				@cgi = request.cgi_compat
 				@conf = conf
 
 				if @conf.options.include?('filter.debug_mode')

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -235,11 +235,12 @@ def calc_links
 		yms.unshift(nil).push(nil)
 		yms[yms.index(this_month) - 1, 3].each do |ym|
 			next unless ym
-			now = @cgi.params['date'] # backup
-			cgi = @cgi.clone
-			cgi.params['date'] = [ym]
-			m = TDiaryMonthWithoutFilter.new(cgi, '', @conf)
-			@cgi.params['date'] = now # restore
+			# look up the neighbour month with a request whose query carries
+			# the month instead of the current date
+			env = @request.env.dup
+			env['REQUEST_METHOD'] = 'GET'
+			env['QUERY_STRING'] = "date=#{ym}"
+			m = TDiaryMonthWithoutFilter.new(TDiary::Request.new(env), '', @conf)
 			m.diaries.delete_if {|date,diary| !diary.visible?}
 			days += m.diaries.keys.sort
 		end

--- a/lib/tdiary/plugin/60sf.rb
+++ b/lib/tdiary/plugin/60sf.rb
@@ -127,7 +127,7 @@ if sf_option( 'selected' ) && !@sf_filters then
 			if File.readable?( path ) then
 				begin
 					require File.expand_path( path )
-					@sf_filters << TDiary::Filter::const_get("#{File::basename(filename, ".rb").capitalize}Filter")::new(@cgi, @conf)
+					@sf_filters << TDiary::Filter::const_get("#{File::basename(filename, ".rb").capitalize}Filter")::new(@request, @conf)
 					plugin_path = "#{dir}/plugin/#{filename}"
 					load_plugin(plugin_path) if File.readable?(plugin_path)
 				rescue Exception

--- a/misc/convert2.rb
+++ b/misc/convert2.rb
@@ -4,6 +4,9 @@
 #
 # Copyright (C) 2001,2002, All right reserved by TADA Tadashi <sho@spc.gr.jp>
 # You can redistribute it and/or modify it under GPL2 or any later version.
+#
+# NOTE: this script is obsolete and no longer expected to work with the
+# current tDiary. To use it, check out a past version of tDiary.
 
 =begin How to usage
 ruby convert2.rb [-p <tDiary path>] [-c <tdiary.conf path>]

--- a/misc/migrate.rb
+++ b/misc/migrate.rb
@@ -6,6 +6,9 @@
 # Copyright (C) 2007, Kazuhiko <kazuhiko@fdiary.net>
 # You can redistribute it and/or modify it under GPL2 or any later version.
 #
+# NOTE: this script is obsolete and no longer expected to work with the
+# current tDiary. To use it, check out a past version of tDiary.
+#
 BEGIN { $stdout.binmode }
 
 require "fileutils"

--- a/misc/plugin/en/disp_referrer.rb
+++ b/misc/plugin/en/disp_referrer.rb
@@ -176,7 +176,7 @@ class DispRef2SetupIF
 	def show_unknown_list
 		urls = DispRef2Cache.new( @setup ).urls( DispRef2URL::Unknown ).keys
 		if urls.size == 0 then
-			urls = DispRef2Latest.new( @cgi, 'latest.rhtml', @conf, @setup ).unknown_urls
+			urls = DispRef2Latest.new( @request, 'latest.rhtml', @conf, @setup ).unknown_urls
 		end
 		urls.reject!{ |url| DispRef2String::url_match?( url, @setup['reflist.ignore_urls'] ) }
 		r = <<-_HTML

--- a/misc/plugin/ja/disp_referrer.rb
+++ b/misc/plugin/ja/disp_referrer.rb
@@ -309,7 +309,7 @@ class DispRef2SetupIF
 	def show_unknown_list
 		urls = DispRef2Cache.new( @setup ).urls( DispRef2URL::Unknown ).keys
 		if urls.size == 0 then
-			urls = DispRef2Latest.new( @cgi, 'latest.rhtml', @conf, @setup ).unknown_urls
+			urls = DispRef2Latest.new( @request, 'latest.rhtml', @conf, @setup ).unknown_urls
 		end
 		urls.reject!{ |url| DispRef2String::url_match?( url, @setup['reflist.ignore_urls'] ) }
 		r = <<-_HTML

--- a/misc/plugin/makelirs.rb
+++ b/misc/plugin/makelirs.rb
@@ -52,12 +52,9 @@ add_update_proc do
 	file = @options['makelirs.file'] || 'antenna.lirs'
 
 	# create_lirs
-	cgi = @cgi.clone
 	conf = @conf.clone
-	def cgi.mobile_agent?; false; end
-	def cgi.mobile_agent?; false; end
 
-	t = TDiaryLatest::new( cgi, "latest.rhtml", conf )
+	t = TDiaryLatest::new( @request, "latest.rhtml", conf )
 	body = t.eval_rhtml
 	# escape comma
 	e = proc{|str| str.gsub(/[,\\]/){ "\\#{$&}" }.gsub( /[\r\n]/, '' ) }


### PR DESCRIPTION
Phase 5b of the @cgi removal plan, following #1344. View and filter constructors now accept only TDiary::Request. The transitional respond_to?(:cgi_compat) sniffs in TDiaryBase, Filter, and TDiaryUpdate are gone. The month navigation in 00default.rb builds a mock GET request carrying the target month in QUERY_STRING instead of cloning the @cgi facade, and the remaining in-repo facade callers (60sf, disp_referrer, makelirs) pass @request.

The CGI class patches in core_ext.rb (valid?, https?, base_url, etc.) are removed since the facade carries its own copies. Their last users, misc/migrate.rb and misc/convert2.rb, are marked obsolete with a note to check out a past tDiary version.

Out-of-repo plugins that construct views or filters with @cgi need to pass @request instead. No spec examples were removed. The Phase 0 tests pass unmodified: 336 examples and rake test 52 tests green.
