### PR TITLE
Issue the comment cookie with an absolute path

### DIFF
--- a/lib/tdiary/view.rb
+++ b/lib/tdiary/view.rb
@@ -203,7 +203,8 @@ module TDiary
 				if @diary and comment_filter( @diary, @comment ) then
 					@diary.add_comment( @comment )
 					dirty = DIRTY_COMMENT
-					cookie_path = File::dirname( @cgi.script_name )
+					script_name = @request.script_name
+					cookie_path = script_name.empty? ? '/' : File::dirname( script_name )
 					cookie_path += '/' if cookie_path !~ /\/$/
 					@cookies << CGI::Cookie::new( {
 						'name' => 'tdiary',

--- a/spec/acceptance/comment_cookie_spec.rb
+++ b/spec/acceptance/comment_cookie_spec.rb
@@ -1,23 +1,17 @@
 require 'acceptance_helper'
 
 feature 'ツッコミ後のcookie' do
-	# The comment is posted via /index.rb, not via the form on /. With the
-	# form the tdiary cookie is issued with "path=./" (derived from the empty
-	# SCRIPT_NAME); browsers fall back to the default-path and restore it,
-	# but the strict rack-test cookie jar drops such a cookie.
 	scenario '次回のコメントフォームにnameとmailが補完される', :exclude_selenium do
 		append_default_diary
-		today = Date.today.strftime('%Y%m%d')
-
-		page.driver.post '/index.rb', {
-			'date' => today,
-			'name' => 'アリス',
-			'mail' => 'alice@example.com',
-			'body' => 'こんにちは!こんにちは!',
-			'comment' => 'comment'
-		}
+		visit '/'
+		click_link 'ツッコミを入れる'
+		fill_in "name", with: "アリス"
+		fill_in "mail", with: "alice@example.com"
+		fill_in "body", with: "こんにちは!こんにちは!"
+		click_button '投稿'
 		expect(page).to have_content "Click here!"
 
+		today = Date.today.strftime('%Y%m%d')
 		visit "/?date=#{today}"
 		expect(page.find('input[name=name]').value).to eq "アリス"
 		expect(page.find('input[name=mail]').value).to eq "alice@example.com"


### PR DESCRIPTION
Behavior change: the tdiary comment cookie is now issued with an absolute path derived from the directory of SCRIPT_NAME (`/` when SCRIPT_NAME is empty), instead of the relative `path=./` that an empty SCRIPT_NAME produced under Rack. Browsers tolerated the relative path via the default-path fallback, but strict cookie jars such as rack-test reject it.

Old cookies stored with the relative path may stop being sent due to the path mismatch, so name/mail completion in the comment form can be lost once; the cookie is reissued on the next comment post.

The cookie round-trip acceptance spec is intentionally updated to post through the normal comment form. It previously went through `page.driver.post '/index.rb'` only to work around the rejected relative path, and that detour is no longer needed. All other specs pass unmodified.

This is kept as a minimal standalone PR so it can be reverted alone if problems surface.
