### PR TITLE
Restrict selenium-webdriver to < 4.45

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :development do
     gem 'rspec'
     gem 'capybara', require: 'capybara/rspec'
     gem 'date', '>= 3.1.1' # for compatibility of capybara
-    gem 'selenium-webdriver'
+    gem 'selenium-webdriver', '< 4.45' # 4.45+ requires Ruby >= 3.3
     gem 'launchy'
     gem 'sequel'
     gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ DEPENDENCIES
   redcarpet
   rexml
   rspec
-  selenium-webdriver
+  selenium-webdriver (< 4.45)
   sequel
   simplecov
   sqlite3


### PR DESCRIPTION
Every weekly Dependabot bundler run has been failing since June. `selenium-webdriver` 4.45 and later require Ruby `>= 3.3`, but `tdiary.gemspec` declares `>= 3.1` and CI still builds on 3.1, so Dependabot cannot resolve the Gemfile and reports `dependency_file_not_resolvable`.

Pinning to `< 4.45` keeps resolution working for as long as Ruby 3.1 is supported. `rake test` and `rspec` both pass on Ruby 3.4.10.

This does not fix the `/misc/paas/heroku not found` failures also mentioned in #1284. Those come from Dependabot security update jobs that discover `misc/paas/heroku/Gemfile.lock` on their own, and `exclude-paths` in `.github/dependabot.yml` does not suppress security updates (dependabot/dependabot-core#14408). Renaming `Gemfile.local` to `Gemfile` there would not help either, since that file is an overlay with no `source` line and is not parseable on its own.

Refs #1284
