### PR TITLE
Fix Docker image build broken by the heroku bundler group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,20 @@
-FROM ruby:3.1
+FROM ruby:3.4
 LABEL maintainer "@tdtds <t@tdtds.jp>"
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY [ "Gemfile", "Gemfile.lock", "/usr/src/app/" ]
+ENV BUNDLE_WITH=docker \
+    BUNDLE_WITHOUT=development:test \
+    BUNDLE_PATH=vendor/bundle
 RUN apt update && apt install -y apt-utils libidn11-dev; \
-    echo 'gem "puma" \n\
-    gem "tdiary-contrib" \n\
-    gem "tdiary-style-gfm" \n\
-    gem "tdiary-style-rd" \n'\
-    > Gemfile.local; \
     gem install bundler && \
-    bundle --path=vendor/bundle --without=development:test --jobs=4 --retry=3
+    bundle install --jobs=4 --retry=3
 
 COPY . /usr/src/app/
 RUN if [ ! -e tdiary.conf ]; then cp tdiary.conf.beginner tdiary.conf; fi && \
-    bundle && \
+    bundle install && \
     bundle exec rake assets:copy
 
 VOLUME [ "/usr/src/app/data", "/usr/src/app/public" ]

--- a/Gemfile
+++ b/Gemfile
@@ -35,13 +35,18 @@ group :development do
   end
 end
 
-# Installed only on Heroku via BUNDLE_WITH=heroku, see misc/paas/heroku
-group :heroku, optional: true do
+# Installed on Heroku (BUNDLE_WITH=heroku) and in the Docker image
+# (BUNDLE_WITH=docker), see misc/paas/heroku and Dockerfile
+group :heroku, :docker, optional: true do
   gem 'puma', require: false
-  gem 'tdiary-io-mongodb', git: 'https://github.com/tdiary/tdiary-io-mongodb.git'
   gem 'tdiary-contrib', git: 'https://github.com/tdiary/tdiary-contrib.git'
   gem 'tdiary-style-gfm'
   gem 'tdiary-style-rd'
+end
+
+# Installed only on Heroku via BUNDLE_WITH=heroku
+group :heroku, optional: true do
+  gem 'tdiary-io-mongodb', git: 'https://github.com/tdiary/tdiary-io-mongodb.git'
   gem 'omniauth'
   gem 'omniauth-github'
   gem 'dalli'


### PR DESCRIPTION
#1351 broke the `Build Docker Image` workflow on master: the Dockerfile's generated `Gemfile.local` declares `tdiary-contrib` from rubygems while the `:heroku` group declares it from git, so the Gemfile fails to parse with "You cannot specify the same gem twice coming from different sources".

Move the shared gems into `group :heroku, :docker, optional: true`, keeping the Heroku-only gems in `:heroku`. `Gemfile.lock` is unchanged. The Dockerfile stops generating `Gemfile.local` and installs via `BUNDLE_WITH=docker`, `BUNDLE_WITHOUT=development:test`, and `BUNDLE_PATH=vendor/bundle`. The base image moves to `ruby:3.4` because the locked `commonmarker` requires Ruby >= 3.2, and bundler 2.7 removed the deprecated `--path` and `--without` flags.

Verified locally: the image builds, a running container serves the tDiary top page with HTTP 200, and bundler's frozen check passes for the `docker`, `heroku`, and development scenarios.

Generated with [Claude Code](https://claude.com/claude-code)
