### PR TITLE
Require gems in bundler groups enabled via BUNDLE_WITH

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :heroku, :docker, optional: true do
   gem 'tdiary-contrib', git: 'https://github.com/tdiary/tdiary-contrib.git'
   gem 'tdiary-style-gfm'
   gem 'tdiary-style-rd'
+  gem 'racc', require: false # rdtool needs racc, a bundled gem since Ruby 3.3
 end
 
 # Installed only on Heroku via BUNDLE_WITH=heroku

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,6 +332,7 @@ DEPENDENCIES
   pit
   pstore
   puma
+  racc
   rack
   rack-session
   racksh

--- a/lib/tdiary/environment.rb
+++ b/lib/tdiary/environment.rb
@@ -24,6 +24,8 @@ if defined?(Bundler)
   env = [:default, :rack]
   env << :development if ENV['RACK_ENV'].nil? || ENV['RACK_ENV'].empty?
   env << ENV['RACK_ENV'].intern if ENV['RACK_ENV']
+  # optional groups enabled via BUNDLE_WITH (:heroku, :docker)
+  env |= (Bundler.settings.with rescue Bundler.settings[:with])
   env = env.reject{|e|
 	  (Bundler.settings.without rescue Bundler.settings[:without]).include? e
   }


### PR DESCRIPTION
After #1351 and #1352 moved the Heroku and Docker gems into optional bundler groups, tdiary-dev crashed at boot with `uninitialized constant TDiary::IO` (503 on every request). `Bundler.require` in `lib/tdiary/environment.rb` only loads `:default`, `:rack`, and the `RACK_ENV` group, so `tdiary-io-mongodb` and friends were installed but never required.

This adds the groups enabled via `BUNDLE_WITH` to the require list. `racc` is also added to the group with `require: false` because `rdtool` (pulled in by `tdiary-style-rd`) requires it and it is a bundled gem since Ruby 3.3, causing a `LoadError` under bundler unless the Gemfile lists it.

Verified with a Docker image built from this branch: the `:docker` group gems load at boot, no `racc` `LoadError`, HTTP 200. Bundler's frozen check passes for the docker, heroku, and dev scenarios.