### PR TITLE
Exclude unneeded bundler groups in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    env:
+      # Building and pushing the gem needs no dev/test gems, and their
+      # native extensions do not build on every Ruby the runner may pick.
+      BUNDLE_WITHOUT: development:test
     steps:
     - uses: actions/checkout@v7
       with:
@@ -21,7 +25,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ruby
+        ruby-version: '3.4'
         bundler-cache: true
     - name: Publish to RubyGems.org
       uses: rubygems/release-gem@v1
@@ -40,12 +44,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      # rake doc needs redcarpet from the development group, but the test
+      # group with its native extensions is unnecessary for packaging.
+      BUNDLE_WITHOUT: test
     steps:
     - uses: actions/checkout@v7
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ruby
+        ruby-version: '3.4'
         bundler-cache: true
     - name: Build tarballs
       env:


### PR DESCRIPTION
The first tag-driven release run for `v5.5.0.beta1` failed at `bundle install` in the push job. The test group pulls in `sqlite3`, whose precompiled gem requires Ruby < 3.5, while `ruby-version: ruby` resolved to Ruby 4.0.6.

Publishing the gem needs no dev or test gems, so the push job now sets `BUNDLE_WITHOUT: development:test`. The package job sets `BUNDLE_WITHOUT: test` because `rake doc` still needs `redcarpet` from the development group. Both jobs pin Ruby to 3.4, the newest version covered by the CI matrix. The vendoring step inside the tarball build is unaffected since it configures its own `BUNDLE_WITHOUT` under `Bundler.with_unbundled_env`.

Failed run: https://github.com/tdiary/tdiary-core/actions/runs/29879912376
