### PR TITLE
Strip compiled artifacts from fallback-vendored gems

### DIFF
--- a/lib/tdiary/tasks/release.rake
+++ b/lib/tdiary/tasks/release.rake
@@ -67,6 +67,9 @@ def vendor_pure_ruby_gems
 			cp spec_file, "#{vendor}/specifications/"
 		elsif NATIVE_GEMS_WITH_RUBY_FALLBACK.include?(spec.name)
 			cp_r gem_dir, "#{vendor}/gems/#{name_version}"
+			# bundle install compiles the extension into lib; drop the ABI-specific
+			# artifacts so only the pure-ruby fallback is shipped
+			Dir["#{vendor}/gems/#{name_version}/**/*.{so,bundle,dll,o}"].each {|f| rm_f f }
 			spec.extensions.clear
 			File.write("#{vendor}/specifications/#{File.basename(spec_file)}", spec.to_ruby)
 			puts "vendored without native extension: #{name_version}"

--- a/lib/tdiary/version.rb
+++ b/lib/tdiary/version.rb
@@ -1,3 +1,3 @@
 module TDiary
-	VERSION = "5.5.0.beta1"
+	VERSION = "5.5.0.beta2"
 end


### PR DESCRIPTION
The `v5.5.0.beta1` full tarball shipped `cgi-0.5.2/lib/cgi/escape.so` even though `vendor_pure_ruby_gems` clears `spec.extensions`. `bundle install` compiles the extension into the gem's `lib` directory, and `cp_r` carried the ABI-specific binary into the tarball meant to be shared across Ruby versions. Remove compiled artifacts after copying so only the pure-ruby fallback is vendored, and bump the version to `5.5.0.beta2` for the next tag test.
