### PR TITLE
Exclude dependabot from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot


### PR DESCRIPTION
The generated notes for `v5.5.0.beta1` were dominated by dependabot entries, which had to be removed by hand. Adding `.github/release.yml` makes `gh release create --generate-notes` in the release workflow skip PRs authored by dependabot from now on.
