### PR TITLE
Declare logger as a direct dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'mail'
 gem 'rake'
 gem 'cgi'
 gem 'pstore'
+gem 'logger'
 
 group :development do
   gem 'pit', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,7 @@ DEPENDENCIES
   fastimage
   hikidoc
   launchy
+  logger
   mail
   memcachier
   mime-types


### PR DESCRIPTION
`lib/tdiary/configuration.rb` requires `logger` directly, but the Gemfile never declared it. It currently works only because `mail` pulls `logger` in as a transitive dependency. Since `logger` is a bundled gem as of Ruby 3.5, `require 'logger'` under bundler would raise `LoadError` once `mail` drops that dependency. This declares `logger` explicitly in the default group. There are no version changes in the lockfile since `logger` was already resolved transitively.
