### PR TITLE
Modernize response generation with integer statuses, Rack cookies and 303 redirects

### DIFF
--- a/lib/tdiary/dispatcher.rb
+++ b/lib/tdiary/dispatcher.rb
@@ -17,24 +17,10 @@ module TDiary
 
 		def call( env )
 			request = adopt_rack_request_to_plain_old_tdiary_style( env )
-			result = @target.run( request )
-			result.headers.reject!{|k,v| k.to_s.downcase == "status" }
-			result.to_a
+			@target.run( request ).to_a
 		end
 
 		class << self
-			# FIXME temporary method during (scratch) refactoring
-			def extract_status_for_legacy_tdiary( head )
-				status_str = head.delete('status')
-				return 200 if !status_str || status_str.empty?
-
-				if m = status_str.match(/(\d+)\s(.+)\Z/)
-					m[1].to_i
-				else
-					200
-				end
-			end
-
 			def index
 				new( :index )
 			end

--- a/lib/tdiary/dispatcher/index_main.rb
+++ b/lib/tdiary/dispatcher/index_main.rb
@@ -25,7 +25,7 @@ module TDiary
 							'vary' => 'User-Agent'
 						}
 						body = ''
-						head['Last-Modified'] = CGI::rfc1123_date( tdiary.last_modified )
+						head['last-modified'] = tdiary.last_modified.httpdate
 
 						if request.head?
 							head['cache-control'] = 'no-cache'

--- a/lib/tdiary/dispatcher/index_main.rb
+++ b/lib/tdiary/dispatcher/index_main.rb
@@ -52,20 +52,7 @@ module TDiary
 						TDiary::Response.new( body, 404, { 'content-type' => 'text/html' } )
 					end
 				rescue TDiary::ForceRedirect
-					head = {
-						#'Location' => $!.path
-						'content-type' => 'text/html',
-					}
-					body = %Q[
-								<html>
-								<head>
-								<meta http-equiv="refresh" content="1;url=#{$!.path}">
-								<title>moving...</title>
-								</head>
-								<body>Wait or <a href="#{$!.path}">Click here!</a></body>
-								</html>]
-					# TODO return code should be 302? (current behaviour returns 200)
-					res = TDiary::Response.new( body, 200, head )
+					res = TDiary::Response.new( '', 303, { 'location' => $!.path } )
 					res.set_header('Set-Cookie', tdiary.cookies.map(&:to_s)) if tdiary && tdiary.cookies.size > 0
 					res
 				end

--- a/lib/tdiary/dispatcher/index_main.rb
+++ b/lib/tdiary/dispatcher/index_main.rb
@@ -16,20 +16,18 @@ module TDiary
 
 			def run
 				begin
-					status = nil
 					@tdiary = create_tdiary
 
 					begin
+						status = 200
 						head = {
 							'content-type' => 'text/html; charset=UTF-8',
 							'vary' => 'User-Agent'
 						}
-						head['status'] = status if status
 						body = ''
 						head['Last-Modified'] = CGI::rfc1123_date( tdiary.last_modified )
 
 						if request.head?
-							head['pragma'] = 'no-cache'
 							head['cache-control'] = 'no-cache'
 							return TDiary::Response.new( '', 200, head )
 						else
@@ -37,15 +35,13 @@ module TDiary
 							body = tdiary.eval_rhtml
 							head['etag'] = %Q["#{OpenSSL::Digest::SHA256.hexdigest( body )}"]
 							if request.env['HTTP_IF_NONE_MATCH'] == head['etag'] and request.get? then
-								head['status'] = CGI::HTTP_STATUS['NOT_MODIFIED']
+								status = 304
 							else
-								head['charset'] = conf.encoding
 								head['content-length'] = body.bytesize.to_s
 							end
-							head['pragma'] = 'no-cache'
 							head['cache-control'] = 'no-cache'
 							head['x-frame-options'] = conf.x_frame_options if conf.x_frame_options
-							res = TDiary::Response.new( body, ::TDiary::Dispatcher.extract_status_for_legacy_tdiary( head ), head )
+							res = TDiary::Response.new( body, status, head )
 							res.set_header('Set-Cookie', tdiary.cookies.map(&:to_s)) if tdiary && tdiary.cookies.size > 0
 							res
 						end

--- a/lib/tdiary/dispatcher/update_main.rb
+++ b/lib/tdiary/dispatcher/update_main.rb
@@ -21,7 +21,6 @@ module TDiary
 					body = tdiary.eval_rhtml
 					head = {
 						'content-type' => 'text/html; charset=UTF-8',
-						'charset' => conf.encoding,
 						'content-length' => body.bytesize.to_s,
 						'vary' => 'User-Agent',
 						'x-frame-options' => 'SAMEORIGIN'

--- a/lib/tdiary/dispatcher/update_main.rb
+++ b/lib/tdiary/dispatcher/update_main.rb
@@ -28,20 +28,7 @@ module TDiary
 					body = ( request.head? ? '' : body )
 					TDiary::Response.new( body, 200, head )
 				rescue TDiary::ForceRedirect
-					head = {
-						#'Location' => $!.path
-						'content-type' => 'text/html',
-					}
-					body = %Q[
-								<html>
-								<head>
-								<meta http-equiv="refresh" content="1;url=#{$!.path}">
-								<title>moving...</title>
-								</head>
-								<body>Wait or <a href="#{$!.path}">Click here!</a></body>
-								</html>]
-					# TODO return code should be 302? (current behaviour returns 200)
-					res = TDiary::Response.new( body, 200, head )
+					res = TDiary::Response.new( '', 303, { 'location' => $!.path } )
 					res.set_header('Set-Cookie', tdiary.cookies.map(&:to_s)) if tdiary && tdiary.cookies.size > 0
 					res
 				end

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -887,7 +887,8 @@ def saveconf_csrf_protection
 			if (check_method & 2 == 2 &&
 			    (old_method & 2 == 0 || old_key != check_key))
 				@conf.save
-				raise ForceRedirect, "#{h @conf.update}?conf=csrf_protection#{@cgi.referer ? '&amp;referer_exists=true' : ''}"
+				# the path is sent as a Location header now, so no HTML escaping
+				raise ForceRedirect, "#{@conf.update}?conf=csrf_protection#{@cgi.referer ? '&referer_exists=true' : ''}"
 			end
 		end
 		err

--- a/lib/tdiary/view.rb
+++ b/lib/tdiary/view.rb
@@ -206,11 +206,15 @@ module TDiary
 					script_name = @request.script_name
 					cookie_path = script_name.empty? ? '/' : File::dirname( script_name )
 					cookie_path += '/' if cookie_path !~ /\/$/
-					@cookies << CGI::Cookie::new( {
-						'name' => 'tdiary',
-						'value' => [@name,@mail],
-						'path' => cookie_path,
-						'expires' => Time::now.gmtime + 90*24*60*60 # 90days
+					# the escaped 'name&mail' multi-value format must be kept;
+					# CGI::Cookie.parse on the reading side splits on '&'
+					@cookies << ::Rack::Utils.set_cookie_header( 'tdiary', {
+						value: [@name, @mail],
+						path: cookie_path,
+						expires: Time::now.gmtime + 90*24*60*60, # 90days
+						secure: @request.ssl?,
+						http_only: true,
+						same_site: :lax
 					} )
 					@io.clear_cache( /(latest|#{@date.strftime( '%Y%m' )})/ )
 				else

--- a/spec/acceptance/append_comment_spec.rb
+++ b/spec/acceptance/append_comment_spec.rb
@@ -11,7 +11,7 @@ feature 'ツッコミの更新' do
 BODY
 
 		click_button '投稿'
-		expect(page).to have_content "Click here!"
+		expect(page).to have_content "こんにちは!こんにちは!"
 
 		visit "/"
 		within('div.day div.comment div.commentshort') {
@@ -43,7 +43,7 @@ BODY
 BODY
 
 		click_button '投稿'
-		expect(page).to have_content "Click here!"
+		expect(page).to have_content "こんばんは!こんばんは!"
 
 		visit "/"
 		within('div.day div.comment div.commentshort') {
@@ -75,7 +75,7 @@ BODY
 BODY
 
 		click_button '投稿'
-		expect(page).to have_content "Click here!"
+		expect(page).to have_content "こんにちは!こんにちは!"
 
 		visit "/"
 		within('ol.recent-comment > li') do

--- a/spec/acceptance/append_diary_spec.rb
+++ b/spec/acceptance/append_diary_spec.rb
@@ -56,7 +56,7 @@ BODY
 		}
 
 		click_button "追記"
-		expect(page).to have_content "Click here!"
+		expect(page).to have_content "さて、Hikiのテストである。"
 
 		visit '/'
 		within('div.day span.title'){ expect(page).to have_content "Hikiのテスト" }

--- a/spec/acceptance/comment_cookie_spec.rb
+++ b/spec/acceptance/comment_cookie_spec.rb
@@ -9,7 +9,7 @@ feature 'ツッコミ後のcookie' do
 		fill_in "mail", with: "alice@example.com"
 		fill_in "body", with: "こんにちは!こんにちは!"
 		click_button '投稿'
-		expect(page).to have_content "Click here!"
+		expect(page).to have_content "こんにちは!こんにちは!"
 
 		today = Date.today.strftime('%Y%m%d')
 		visit "/?date=#{today}"

--- a/spec/acceptance/save_conf_comment_spec.rb
+++ b/spec/acceptance/save_conf_comment_spec.rb
@@ -31,7 +31,7 @@ feature 'ツッコミ設定の利用' do
 BODY
 
 		click_button '投稿'
-		expect(page).to have_content "Click here!"
+		expect(page).to have_content "こんばんは!こんばんは!"
 
 		visit '/update.rb?conf=comment'
 		fill_in 'comment_limit', with: '1'

--- a/spec/acceptance/save_conf_dnsbl_spec.rb
+++ b/spec/acceptance/save_conf_dnsbl_spec.rb
@@ -119,13 +119,15 @@ BODY
 		expect(IPSocket).to receive(:getaddress).exactly(0)
 		expect(Resolv).to receive(:getaddress).exactly(0)
 
-		append_default_diary
-
 		visit '/update.rb?conf=dnsblfilter'
 		fill_in 'spamlookup.ip.list', with: "bsb.spamlookup.net"
 		fill_in 'spamlookup.domain.list', with: "bsb.spamlookup.net"
 		fill_in 'spamlookup.safe_domain.list', with: "www.example.com"
 		page.all('div.saveconf').first.click_button 'OK'
+
+		# configure the safe list before appending; following the 303 after
+		# the append carries an own-site referer through the spam filter
+		append_default_diary
 
 		visit "/"
 		click_link 'ツッコミを入れる'

--- a/spec/acceptance/save_conf_referer_spec.rb
+++ b/spec/acceptance/save_conf_referer_spec.rb
@@ -16,12 +16,15 @@ feature 'リンク元設定の利用' do
 	end
 
 	scenario 'リンク元記録の除外設定が動いている' do
-		append_default_diary
 		visit '/update.rb?conf=referer'
 		fill_in 'no_referer', with: '^http://www\.example\.com/.*'
 
 		page.all('div.saveconf').first.click_button('OK')
 		# within('title') { page.should have_content('(設定完了)') }
+
+		# configure the exclusion before appending; following the 303 after
+		# the append carries an own-site referer that would be recorded
+		append_default_diary
 
 		click_link '最新'
 		today = Date.today.strftime('%Y年%m月%d日')

--- a/spec/acceptance/update_diary_spec.rb
+++ b/spec/acceptance/update_diary_spec.rb
@@ -65,7 +65,7 @@ BODY
 		within('div.textarea') { fill_in "body", with: '' }
 
 		click_button "登録"
-		expect(page).to have_content "Click here!"
+		expect(page.current_url).to include "date=#{Date.today.strftime('%Y%m%d')}"
 
 		visit '/'
 		within('div.day') { expect(page).to have_no_css('h3') }
@@ -82,7 +82,7 @@ BODY
 		check 'hide'
 
 		click_button "登録"
-		expect(page).to have_content "Click here!"
+		expect(page.current_url).to include "date=#{Date.today.strftime('%Y%m%d')}"
 
 		visit '/'
 		expect(page).to have_no_css('div[class="day"]')

--- a/spec/core/cgi_endpoint_smoke_spec.rb
+++ b/spec/core/cgi_endpoint_smoke_spec.rb
@@ -89,10 +89,10 @@ describe 'index.rb comment POST as a plain CGI program' do
 		FileUtils.remove_entry @workdir
 	end
 
-	it 'accepts the comment and sets the tdiary cookie' do
-		expect(@head).to match(/^Status: 200/), -> { "head: #{@head.inspect}\nstderr: #{@stderr}" }
+	it 'accepts the comment, sets the tdiary cookie and redirects to the day' do
+		expect(@head).to match(/^Status: 303/), -> { "head: #{@head.inspect}\nstderr: #{@stderr}" }
 		expect(@head).to match(/^set-cookie: tdiary=alice/i), -> { "head: #{@head.inspect}\nstderr: #{@stderr}" }
-		expect(@body).to include('Click here!')
+		expect(@head).to match(/^location: .*date=20260719/i), -> { "head: #{@head.inspect}\nstderr: #{@stderr}" }
 	end
 end
 

--- a/spec/core/update_multipart_spec.rb
+++ b/spec/core/update_multipart_spec.rb
@@ -43,14 +43,14 @@ describe 'multipart POST to the update dispatcher' do
 			'year' => '2026', 'month' => '4', 'day' => '15',
 			'title' => 'multipart test', 'body' => 'first version', 'append' => '追記'
 		}, 'HTTP_REFERER' => referer
-		expect(last_response.status).to eq 200
+		expect(last_response.status).to eq 303
 
 		post '/update.rb', {
 			'year' => '2026', 'month' => '4', 'day' => '15', 'old' => '20260415',
 			'title' => 'multipart test', 'body' => 'replaced version', 'replace' => '上書き',
 			'date' => Rack::Test::UploadedFile.new(StringIO.new('20260415'), 'text/plain', original_filename: 'date.txt')
 		}, 'HTTP_REFERER' => referer
-		expect(last_response.status).to eq 200
+		expect(last_response.status).to eq 303
 
 		get '/?date=20260415'
 		expect(last_response.status).to eq 200


### PR DESCRIPTION
Part of the `@cgi` removal plan, phase 6a. Responses now pass integer statuses directly instead of a `'status'` pseudo header that `Dispatcher` extracted on every call, and the `'charset'` pseudo header and `pragma: no-cache` are gone. `CGI::HTTP_STATUS` and `CGI::rfc1123_date` are replaced with integer statuses and `Time#httpdate`. The tdiary comment cookie is built with `Rack::Utils.set_cookie_header` and now carries `SameSite=Lax`, `HttpOnly` and, on HTTPS, `Secure`, keeping the escaped `name&mail` multi-value format that plugins parse. `ForceRedirect` responds with 303 and a `Location` header instead of 200 with a meta refresh, so the csrf_protection redirect drops its `&amp;` HTML escaping. Specs asserting the interstitial page were updated intentionally, and two acceptance scenarios configure referer exclusion and the DNSBL safe list before appending because rack-test now follows the redirect with an own-site `Referer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
