### PR TITLE
Read the request directly in core instead of the @cgi facade

### DIFF
--- a/lib/tdiary/admin.rb
+++ b/lib/tdiary/admin.rb
@@ -8,7 +8,7 @@ module TDiary
 			super
 
 			begin
-				@date = Time::local( @cgi.params['year'][0].to_i, @cgi.params['month'][0].to_i, @cgi.params['day'][0].to_i )
+				@date = Time::local( @request.param('year').to_i, @request.param('month').to_i, @request.param('day').to_i )
 			rescue ArgumentError, NameError
 				raise TDiaryError, 'bad date'
 			end
@@ -71,12 +71,12 @@ module TDiary
 		def initialize( cgi, rhtm, conf )
 			super
 
-			@title = @cgi.params['title'][0]
-			@body = @cgi.params['body'][0]
+			@title = @request.param('title')
+			@body = @request.param('body')
 			@title = @conf.to_native( @title )
 			@body = @conf.to_native( @body )
-			@old_date = @cgi.params['old'][0]
-			@hide = @cgi.params['hide'][0] == 'true' ? true : false
+			@old_date = @request.param('old')
+			@hide = @request.param('hide') == 'true' ? true : false
 
 			@io.transaction( @date ) do |diaries|
 				@diaries = diaries
@@ -107,13 +107,11 @@ module TDiary
 	#
 	class TDiaryUpdate < TDiaryAdmin
 		def initialize( request, rhtml, conf )
-			# @cgi is not derived yet before super; go through the facade here
-			params = request.cgi_compat.params
-			@title = params['title'][0]
-			@body = params['body'][0]
+			@title = request.param('title')
+			@body = request.param('body')
 			@title = conf.to_native( @title )
 			@body = conf.to_native( @body )
-			@hide = params['hide'][0] == 'true' ? true : false
+			@hide = request.param('hide') == 'true' ? true : false
 			super
 		end
 
@@ -140,7 +138,7 @@ module TDiary
 				@date = newdate
 			end
 
-			@author = @conf.multi_user ? @cgi.remote_user : nil
+			@author = @conf.multi_user ? @request.remote_user : nil
 
 			@io.transaction( @date ) do |diaries|
 				@diaries = diaries
@@ -166,7 +164,7 @@ module TDiary
 	class TDiaryReplace < TDiaryUpdate
 		def initialize( cgi, rhtm, conf )
 			super
-			old_date = @cgi.params['old'][0]
+			old_date = @request.param('old')
 
 			@io.transaction( @date ) do |diaries|
 				@diaries = diaries
@@ -203,7 +201,7 @@ module TDiary
 				if @diary then
 					idx = 0
 					@diary.each_comment do |com|
-						com.show = @cgi.params[(idx += 1).to_s][0] == 'true' ? true : false;
+						com.show = @request.param((idx += 1).to_s) == 'true' ? true : false;
 					end
 					self << @diary
 					@io.clear_cache( /(latest|#{@date.strftime( '%Y%m' )})/ )

--- a/lib/tdiary/author_only_base.rb
+++ b/lib/tdiary/author_only_base.rb
@@ -91,11 +91,11 @@ EOS
 		def initialize( cgi, rhtm, conf )
 			super
 
-			if @cgi.valid?( 'date' ) then
-				if @cgi.params['date'][0].kind_of?( String ) then
-					date = @cgi.params['date'][0]
+			if @request.valid?( 'date' ) then
+				if @request.param('date').kind_of?( String ) then
+					date = @request.param('date')
 				else
-					date = @cgi.params['date'][0].read
+					date = @request.param('date').read
 				end
 				@date = Time::local( *date.scan( /(\d{4})(\d\d)(\d\d)/ )[0] )
 			else
@@ -125,7 +125,7 @@ EOS
 
 		def initialize( cgi, rhtml, conf )
 			super
-			@key = @cgi.params['conf'][0] || ''
+			@key = @request.param('conf') || ''
 		end
 	end
 

--- a/lib/tdiary/base.rb
+++ b/lib/tdiary/base.rb
@@ -203,7 +203,7 @@ module TDiary
 		def initialize(cgi, rhtml, conf)
 			super
 
-			tdiary = tdiary_class(@cgi.params['date'][0] || '').new(@request, '', conf)
+			tdiary = tdiary_class(@request.param('date') || '').new(@request, '', conf)
 			@date = tdiary.date
 			@diaries = tdiary.diaries
 			@last_modified = Time.now
@@ -221,7 +221,7 @@ module TDiary
 
 		def plugin_name
 			# plugin name MUST contain only words ([a-zA-Z0-9_])
-			@plugin_name ||= (@cgi.params['plugin'][0] || '').match(/^(\w+)$/).to_a[1]
+			@plugin_name ||= (@request.param('plugin') || '').match(/^(\w+)$/).to_a[1]
 			raise TDiary::PermissionError.new('invalid plugin name') unless @plugin_name
 			@plugin_name
 		end

--- a/lib/tdiary/cgi_compat.rb
+++ b/lib/tdiary/cgi_compat.rb
@@ -16,35 +16,49 @@ module TDiary
 			# built eagerly so that a clone (Object#clone copies instance
 			# variables by reference) shares the same params Hash, like a
 			# cloned CGI instance does. Plugins may still rely on this.
-			@params = build_params
+			@params = request.cgi_params
 		end
 
 		attr_reader :params
 
-		def valid?( param, idx = 0 )
-			params[param] and params[param][idx] and params[param][idx].length > 0
+		# the env of the wrapped request, for the stateless RequestExtension
+		# readers (remote_addr, https?, tdiary_base_url, ...)
+		def env
+			@request.env
+		end
+
+		# the stateful RequestExtension readers delegate to the wrapped
+		# request, so core code reading the request directly sees the same
+		# params Hash and the same hidden-referer state as plugins do
+		# through this facade
+		def cgi_params
+			@request.cgi_params
+		end
+
+		def cgi_cookies
+			@request.cgi_cookies
+		end
+
+		def hide_referer!
+			@request.hide_referer!
+		end
+
+		def referer
+			@request.referer
 		end
 
 		def cookies
 			# CGI::Cookie keeps the multi-value cookie behaviour (00default.rb
 			# reads name and mail from the two values of the tdiary cookie)
-			@cookies ||= CGI::Cookie.parse( env_table['HTTP_COOKIE'] )
+			cgi_cookies
 		end
 
 		def env_table
 			@request.env
 		end
 
-		def referer
-			env_table['HTTP_REFERER']
-		end
-
 		def user_agent
 			env_table['HTTP_USER_AGENT']
-		end
-
-		def remote_addr
-			env_table['REMOTE_ADDR']
 		end
 
 		def request_method
@@ -53,10 +67,6 @@ module TDiary
 
 		def script_name
 			env_table['SCRIPT_NAME']
-		end
-
-		def remote_user
-			env_table['REMOTE_USER']
 		end
 
 		def auth_type
@@ -77,12 +87,6 @@ module TDiary
 
 		# the URL helpers below come from the CGI patches that used to live
 		# in core_ext.rb
-		def https?
-			return true if env_table['HTTP_X_FORWARDED_PROTO'] == 'https'
-			return false if env_table['HTTPS'].nil? or /off/i =~ env_table['HTTPS'] or env_table['HTTPS'] == ''
-			true
-		end
-
 		def request_uri
 			_request_uri = env_table['REQUEST_URI']
 			_script_name = env_table['SCRIPT_NAME']
@@ -103,79 +107,7 @@ module TDiary
 		end
 
 		def base_url
-			return '' unless script_name
-			begin
-				script_dirname = script_name.empty? ? '' : File::dirname(script_name)
-				if https?
-					port = (server_port == 443) ? '' : ':' + server_port.to_s
-					"https://#{server_name}#{port}#{script_dirname}/"
-				else
-					port = (server_port == 80) ? '' : ':' + server_port.to_s
-					"http://#{server_name}#{port}#{script_dirname}/"
-				end.sub(%r|/+$|, '/')
-			rescue SecurityError
-				''
-			end
-		end
-
-	private
-
-		def build_params
-			source =
-				if request_method == 'POST'
-					if %r|\Amultipart/form-data|.match?( env_table['CONTENT_TYPE'].to_s )
-						@request.POST
-					else
-						# Rack's nested query parser behind request.POST keeps only
-						# the last of duplicated keys; CGI collects all of them
-						::Rack::Utils.parse_query( read_raw_body )
-					end
-				else
-					::Rack::Utils.parse_query( env_table['QUERY_STRING'].to_s )
-				end
-
-			params = {}
-			source.each do |key, value|
-				values = value.kind_of?( Array ) ? value : [value]
-				params[key] = values.map {|v| normalize_value( v ) }
-			end
-			params.default = []
-			params
-		end
-
-		def read_raw_body
-			input = env_table['rack.input']
-			return '' unless input
-			# Rack::Request#POST leaves rack.input at EOF, so rewind first in
-			# case the request params were already parsed
-			input.rewind if input.respond_to?( :rewind )
-			body = input.read
-			input.rewind if input.respond_to?( :rewind )
-			body || ''
-		end
-
-		def normalize_value( value )
-			if value.kind_of?( Hash ) and value[:tempfile]
-				# Rack multipart file upload: expose an object responding to
-				# read, which is all the consumers use
-				value[:tempfile]
-			else
-				repair_encoding( value.to_s )
-			end
-		end
-
-		# CGI/FCGI hosting retries broken UTF-8 input as Shift_JIS (index.rb,
-		# misc/lib/fcgi_patch.rb). The facade implements the same fallback on
-		# each value: invalid UTF-8 is converted from Shift_JIS when possible,
-		# otherwise scrubbed.
-		def repair_encoding( str )
-			str = str.dup.force_encoding( Encoding::UTF_8 ) unless str.encoding == Encoding::UTF_8
-			return str if str.valid_encoding?
-			begin
-				str.dup.force_encoding( Encoding::Shift_JIS ).encode( Encoding::UTF_8 )
-			rescue EncodingError
-				str.scrub
-			end
+			tdiary_base_url
 		end
 	end
 end

--- a/lib/tdiary/core_ext.rb
+++ b/lib/tdiary/core_ext.rb
@@ -1,6 +1,9 @@
 require 'emot'
 
 module TDiary
+	# CGI-semantics readers shared by TDiary::Request and the CGICompat
+	# facade (which forwards env to the request it wraps, so state memoized
+	# in the env is visible through either object).
 	module RequestExtension
 		# backward compatibility, returns NOT mobile phone always
 		def mobile_agent?
@@ -10,6 +13,137 @@ module TDiary
 		# backward compatibility, returns NOT smartphone always
 		def smartphone?
 			false
+		end
+
+		# params with CGI semantics, unlike Rack::Request#params: POST reads
+		# only the body, every value is an Array, unknown keys yield [],
+		# duplicated keys collect all values, broken UTF-8 input is retried
+		# as Shift_JIS and multipart uploads are normalized to their
+		# tempfiles. Memoized so the request and its CGICompat facade (which
+		# delegates here) share one Hash; plugins mutate it through
+		# @cgi.params.
+		def cgi_params
+			@cgi_params ||= build_cgi_params
+		end
+
+		# single-value accessor over cgi_params; nil when the key is absent
+		def param( key, idx = 0 )
+			cgi_params[key][idx]
+		end
+
+		def valid?( param, idx = 0 )
+			cgi_params[param] and cgi_params[param][idx] and cgi_params[param][idx].length > 0
+		end
+
+		# multi-value cookies, unlike Rack::Request#cookies: CGI::Cookie
+		# splits each value on '&' (the tdiary cookie carries 'name&mail')
+		def cgi_cookies
+			@cgi_cookies ||= CGI::Cookie.parse( env['HTTP_COOKIE'] )
+		end
+
+		# TDiaryView hides the referer for the rest of the request when the
+		# referer filters reject it; plugins observe nil through the @cgi
+		# facade too, which delegates both methods to the request
+		def hide_referer!
+			@referer_hidden = true
+		end
+
+		def referer
+			@referer_hidden ? nil : env['HTTP_REFERER']
+		end
+
+		def remote_addr
+			env['REMOTE_ADDR']
+		end
+
+		def remote_user
+			env['REMOTE_USER']
+		end
+
+		def https?
+			return true if env['HTTP_X_FORWARDED_PROTO'] == 'https'
+			return false if env['HTTPS'].nil? or /off/i =~ env['HTTPS'] or env['HTTPS'] == ''
+			true
+		end
+
+		# not Rack::Request#base_url (scheme and host only): the CGI flavour
+		# with the SCRIPT_NAME dirname and a trailing '/'
+		def tdiary_base_url
+			script_name = env['SCRIPT_NAME']
+			return '' unless script_name
+			begin
+				script_dirname = script_name.empty? ? '' : File::dirname( script_name )
+				server_name = env['SERVER_NAME']
+				server_port = env['SERVER_PORT'].to_i
+				if https?
+					port = (server_port == 443) ? '' : ':' + server_port.to_s
+					"https://#{server_name}#{port}#{script_dirname}/"
+				else
+					port = (server_port == 80) ? '' : ':' + server_port.to_s
+					"http://#{server_name}#{port}#{script_dirname}/"
+				end.sub(%r|/+$|, '/')
+			rescue SecurityError
+				''
+			end
+		end
+
+	private
+
+		def build_cgi_params
+			source =
+				if env['REQUEST_METHOD'] == 'POST'
+					if %r|\Amultipart/form-data|.match?( env['CONTENT_TYPE'].to_s )
+						self.POST
+					else
+						# Rack's nested query parser behind Rack::Request#POST keeps
+						# only the last of duplicated keys; CGI collects all of them
+						::Rack::Utils.parse_query( read_raw_body )
+					end
+				else
+					::Rack::Utils.parse_query( env['QUERY_STRING'].to_s )
+				end
+
+			params = {}
+			source.each do |key, value|
+				values = value.kind_of?( Array ) ? value : [value]
+				params[key] = values.map {|v| normalize_cgi_value( v ) }
+			end
+			params.default = []
+			params
+		end
+
+		def read_raw_body
+			input = env['rack.input']
+			return '' unless input
+			# Rack::Request#POST leaves rack.input at EOF, so rewind first in
+			# case the request params were already parsed
+			input.rewind if input.respond_to?( :rewind )
+			body = input.read
+			input.rewind if input.respond_to?( :rewind )
+			body || ''
+		end
+
+		def normalize_cgi_value( value )
+			if value.kind_of?( Hash ) and value[:tempfile]
+				# Rack multipart file upload: expose an object responding to
+				# read, which is all the consumers use
+				value[:tempfile]
+			else
+				repair_encoding( value.to_s )
+			end
+		end
+
+		# CGI/FCGI hosting retries broken UTF-8 input as Shift_JIS. The same
+		# fallback is applied to each value: invalid UTF-8 is converted from
+		# Shift_JIS when possible, otherwise scrubbed.
+		def repair_encoding( str )
+			str = str.dup.force_encoding( Encoding::UTF_8 ) unless str.encoding == Encoding::UTF_8
+			return str if str.valid_encoding?
+			begin
+				str.dup.force_encoding( Encoding::Shift_JIS ).encode( Encoding::UTF_8 )
+			rescue EncodingError
+				str.scrub
+			end
 		end
 	end
 end

--- a/lib/tdiary/filter.rb
+++ b/lib/tdiary/filter.rb
@@ -35,7 +35,7 @@ module TDiary
 				return if @debug_mode == DEBUG_NONE
 				return if @debug_mode == DEBUG_SPAM and level == DEBUG_FULL
 
-				TDiary.logger.info("#{@cgi.remote_addr}->#{(@cgi.params['date'][0] || 'no date').dump}: #{msg}")
+				TDiary.logger.info("#{@request.remote_addr}->#{(@request.param('date') || 'no date').dump}: #{msg}")
 			end
 		end
 	end

--- a/lib/tdiary/filter/default.rb
+++ b/lib/tdiary/filter/default.rb
@@ -9,7 +9,7 @@ module TDiary
 	module Filter
 		class DefaultFilter < Filter
 			def comment_filter( diary, comment )
-				if 'POST' != @cgi.request_method then
+				if 'POST' != @request.request_method then
 					return false
 				end
 				if comment.name.strip.empty? or comment.body.strip.empty? then
@@ -29,7 +29,7 @@ module TDiary
 					false
 				#elsif /[\x00-\x20\x7f-\xff]/ =~ referer then
 				#	false
-				elsif @conf.bot =~ @cgi.user_agent
+				elsif @conf.bot =~ @request.user_agent
 					false
 				elsif %r|^https?://|i =~ referer
 					ref = CGI::unescape( referer.sub( /#.*$/, '' ).sub( /\?\d{8}$/, '' ) ).force_encoding('ASCII-8BIT')

--- a/lib/tdiary/filter/spam.rb
+++ b/lib/tdiary/filter/spam.rb
@@ -228,8 +228,8 @@ module TDiary
 					return @filter_mode
 				end
 
-				if @bad_ips.detect {|p| p =~ @cgi.remote_addr}
-					debug( "ip address blacklisted: /#{p}/ =~ #{@cgi.remote_addr}" )
+				if @bad_ips.detect {|p| p =~ @request.remote_addr}
+					debug( "ip address blacklisted: /#{p}/ =~ #{@request.remote_addr}" )
 					comment.show = false
 					return @filter_mode
 				end

--- a/lib/tdiary/plugin.rb
+++ b/lib/tdiary/plugin.rb
@@ -349,7 +349,7 @@ module TDiary
 		end
 
 		def conf_current_style( key )
-			if key == @cgi.params['conf'][0] then
+			if key == @request.param('conf') then
 				'selected'
 			else
 				'other'

--- a/lib/tdiary/view.rb
+++ b/lib/tdiary/view.rb
@@ -7,12 +7,12 @@ module TDiary
 		def initialize( cgi, rhtml, conf )
 			super
 
-			unless referer_filter( @cgi.referer )
-				def @cgi.referer; nil; end
+			unless referer_filter( @request.referer )
+				@request.hide_referer!
 			end
 
 			# save referer to latest
-			if (!@conf.referer_day_only or (@cgi.params['date'][0] and @cgi.params['date'][0].length == 8)) and @cgi.referer then
+			if (!@conf.referer_day_only or (@request.param('date') and @request.param('date').length == 8)) and @request.referer then
 				ym = latest_month
 				@date = ym ? Time::local( ym[0], ym[1] ) : Time::now
 				@io.transaction( @date ) do |diaries|
@@ -23,7 +23,7 @@ module TDiary
 						break if @diary.visible?
 					end
 					if @diary then
-						@diary.add_referer( @cgi.referer )
+						@diary.add_referer( @request.referer )
 						dirty = DIRTY_REFERER
 					end
 					dirty
@@ -121,7 +121,7 @@ module TDiary
 
 			begin
 				# time is noon for easy to calc leap second.
-				@date = Time::local( *@cgi.params['date'][0].scan( /^(\d{4})(\d\d)(\d\d)$/ )[0] ) + 12*60*60
+				@date = Time::local( *@request.param('date').scan( /^(\d{4})(\d\d)(\d\d)$/ )[0] ) + 12*60*60
 				load( @date )
 			rescue ArgumentError, NameError
 				raise TDiaryError, 'bad date'
@@ -149,8 +149,8 @@ module TDiary
 					@diaries = diaries
 					dirty = DIRTY_NONE
 					@diary = self[date]
-					if @diary and @cgi.referer then
-						@diary.add_referer( @cgi.referer )
+					if @diary and @request.referer then
+						@diary.add_referer( @request.referer )
 						dirty = DIRTY_REFERER
 					end
 					dirty
@@ -161,11 +161,11 @@ module TDiary
 		end
 
 		def cookie_name
-			@cgi.cookies['tdiary'][0] or ''
+			@request.cgi_cookies['tdiary'][0] or ''
 		end
 
 		def cookie_mail
-			@cgi.cookies['tdiary'][1] or ''
+			@request.cgi_cookies['tdiary'][1] or ''
 		end
 	end
 
@@ -189,9 +189,9 @@ module TDiary
 
 		def load( date )
 			@date = date
-			@name = @cgi.params['name'][0]
-			@mail = @cgi.params['mail'][0]
-			@body = @cgi.params['body'][0]
+			@name = @request.param('name')
+			@mail = @request.param('mail')
+			@body = @request.param('body')
 			@name = @conf.to_native( @name )
 			@body = @conf.to_native( @body )
 			@comment = Comment::new( @name, @mail, @body )
@@ -259,7 +259,7 @@ module TDiary
 			super
 
 			begin
-				date = Time::local( *@cgi.params['date'][0].scan( /^(\d{4})(\d\d)$/ )[0] )
+				date = Time::local( *@request.param('date').scan( /^(\d{4})(\d\d)$/ )[0] )
 				d1 = @date.dup.gmtime if @date
 				d2 = date.dup.gmtime
 				if not @date or d1.year != d2.year or d1.month != d2.month then
@@ -285,7 +285,7 @@ module TDiary
 			super
 
 			@diaries = {}
-			month, day = @cgi.params['date'][0].scan(/^(\d\d)(\d\d)$/)[0]
+			month, day = @request.param('date').scan(/^(\d\d)(\d\d)$/)[0]
 			nyear(month).each do |y, m|
 				@date = Time::local(y, m)
 				@io.transaction(@date) do |diaries|
@@ -323,8 +323,8 @@ module TDiary
 		def initialize( cgi, rhtml, conf )
 			super
 
-			if @cgi.params['date'][0] then
-				ym = [@cgi.params['date'][0][0,4].to_i, @cgi.params['date'][0][4,2].to_i]
+			if @request.param('date') then
+				ym = [@request.param('date')[0,4].to_i, @request.param('date')[4,2].to_i]
 				@date = nil
 			else
 				ym = latest_month
@@ -334,8 +334,8 @@ module TDiary
 				@date = ym ? Time::local( ym[0], ym[1] ) : Time::now
 				@io.transaction( @date ) do |diaries|
 					@diaries = diaries
-					if @cgi.params['date'][0] then
-						@diary = @diaries[@cgi.params['date'][0][0,8]]
+					if @request.param('date') then
+						@diary = @diaries[@request.param('date')[0,8]]
 						@date = @diary.date if @diary
 					end
 					unless @diary then
@@ -447,16 +447,16 @@ module TDiary
 		end
 
 		def start_date
-			if @cgi.params['date'][0] then
-				@cgi.params['date'][0][0,8]
+			if @request.param('date') then
+				@request.param('date')[0,8]
 			else
 				'99999999' # max of date string
 			end
 		end
 
 		def limit_size( default_limit )
-			if @cgi.params['date'][0] then
-				date = @cgi.params['date'][0]
+			if @request.param('date') then
+				date = @request.param('date')
 				limit = date[9,date.length-9].to_i
 				limit = 30 if limit > 30
 				limit

--- a/lib/tdiary/view_helper.rb
+++ b/lib/tdiary/view_helper.rb
@@ -1,15 +1,23 @@
 module TDiary
   module ViewHelper
 		def bot?
-			@conf.bot =~ @cgi.user_agent
+			@conf.bot =~ view_helper_request.user_agent
 		end
 
     def base_url
       if @conf.options['base_url'] && @conf.options['base_url'].length > 0
         @conf.options['base_url']
       else
-        @cgi.base_url
+        view_helper_request.tdiary_base_url
       end
+    end
+
+  private
+
+    # plugins include this helper into objects that hold only the @cgi
+    # facade (misc/plugin/makerss.rb); fall back to its wrapped request
+    def view_helper_request
+      @request || @cgi.request
     end
   end
 end


### PR DESCRIPTION
Core code still read the request through the `@cgi` compatible facade. This PR inverts the reference direction. The CGI semantics of `CGICompat#build_params` (POST body only, array values, unknown keys as `[]`, Shift_JIS repair, multipart tempfiles) move into `TDiary::RequestExtension` as `cgi_params`, together with `param`, `valid?`, `cgi_cookies`, `referer` with a `hide_referer!` switch, `remote_addr`, `remote_user`, `https?` and `tdiary_base_url`. `CGICompat` delegates its stateful readers to the wrapped request, and the view, admin, filter and helper classes read `@request` directly. The singleton `def @cgi.referer; nil; end` override becomes `request.hide_referer!`, still visible to plugins through the facade.

This is behavior preserving. The `@cgi` facade remains the plugin boundary (`plugin_params`, in-repo plugins, `misc/filter` subclasses), the shared examples locking the facade surface are unmodified, and the full spec (336 examples) plus `rake test` stay green on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
