### PR TITLE
Replace selenium-webdriver with cuprite for acceptance specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :development do
     gem 'rspec'
     gem 'capybara', require: 'capybara/rspec'
     gem 'date', '>= 3.1.1' # for compatibility of capybara
-    gem 'selenium-webdriver', '< 4.45' # 4.45+ requires Ruby >= 3.3
+    gem 'cuprite'
     gem 'launchy'
     gem 'sequel'
     gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,9 @@ GEM
     commonmarker (2.9.0-x86_64-linux-musl)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
+    cuprite (0.17)
+      capybara (~> 3.0)
+      ferrum (~> 0.17.0)
     dalli (5.0.5)
       logger
     date (3.5.1)
@@ -79,6 +82,12 @@ GEM
     faraday (0.17.6)
       multipart-post (>= 1.2, < 3)
     fastimage (2.4.1)
+    ferrum (0.17.2)
+      addressable (~> 2.5)
+      base64 (~> 0.2)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
     hashie (5.1.0)
       logger
     hikidoc (0.1.1)
@@ -221,14 +230,7 @@ GEM
       rspec-support (~> 3.13.0)
     rspec-support (3.13.6)
     ruby2_keywords (0.0.5)
-    rubyzip (2.4.1)
     securerandom (0.4.1)
-    selenium-webdriver (4.33.0)
-      base64 (~> 0.2)
-      logger (~> 1.4)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
     sequel (5.106.0)
       bigdecimal
     simplecov (1.0.3)
@@ -279,7 +281,10 @@ GEM
     unf_ext (0.0.9.1)
     version_gem (1.1.14)
     webrick (1.9.2)
-    websocket (1.2.11)
+    websocket-driver (0.8.2)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -305,6 +310,7 @@ DEPENDENCIES
   capybara
   cgi
   connection_pool
+  cuprite
   dalli
   date (>= 3.1.1)
   emot
@@ -329,7 +335,6 @@ DEPENDENCIES
   redcarpet
   rexml
   rspec
-  selenium-webdriver (< 4.45)
   sequel
   simplecov
   sqlite3

--- a/spec/acceptance/comment_cookie_spec.rb
+++ b/spec/acceptance/comment_cookie_spec.rb
@@ -1,7 +1,7 @@
 require 'acceptance_helper'
 
 feature 'ツッコミ後のcookie' do
-	scenario '次回のコメントフォームにnameとmailが補完される', :exclude_selenium do
+	scenario '次回のコメントフォームにnameとmailが補完される', :exclude_webrick do
 		append_default_diary
 		visit '/'
 		click_link 'ツッコミを入れる'

--- a/spec/acceptance/save_conf_default_spec.rb
+++ b/spec/acceptance/save_conf_default_spec.rb
@@ -124,7 +124,7 @@ FOOTER
 		expect(page).to have_field('hour_offset', with: '-24.0')
 	end
 
-	scenario 'Rack 環境でテーマ選択が保存される', :exclude_selenium do
+	scenario 'Rack 環境でテーマ選択が保存される', :exclude_webrick do
 		visit '/update.rb?conf=theme'
 		select 'Tdiary1', from: 'theme'
 
@@ -147,10 +147,8 @@ FOOTER
 		page.all('div.saveconf').first.click_button "OK"
 
 		click_link '最新'
-		within('head') {
-			expect(page).to have_css('link[href="theme/base.css"]')
-			expect(page).to have_css('link[href="theme/tdiary1/tdiary1.css"]')
-		}
+		expect(page.body).to be_include('href="theme/base.css"')
+		expect(page.body).to be_include('href="theme/tdiary1/tdiary1.css"')
 
 		visit '/update.rb?conf=theme'
 		within('select option[selected]'){

--- a/spec/acceptance/save_conf_dnsbl_spec.rb
+++ b/spec/acceptance/save_conf_dnsbl_spec.rb
@@ -1,7 +1,7 @@
 require 'acceptance_helper'
 require 'resolv'
 
-feature 'spamフィルタ設定の利用', :exclude_selenium do
+feature 'spamフィルタ設定の利用', :exclude_webrick do
 	scenario 'IPベースのブラックリストの spam-champuru が spamlookup に置き換わる' do
 		visit '/update.rb?conf=dnsblfilter'
 		fill_in 'spamlookup.ip.list', with: "dnsbl.spam-champuru.livedoor.com"

--- a/spec/acceptance/save_conf_referer_spec.rb
+++ b/spec/acceptance/save_conf_referer_spec.rb
@@ -32,7 +32,7 @@ feature 'リンク元設定の利用' do
 		within('div.day div.refererlist') { expect(page).to have_no_link('http://www.example.com') }
 	end
 
-	scenario 'リンク元の置換が動いている', :exclude_selenium do
+	scenario 'リンク元の置換が動いている', :exclude_webrick do
 		append_default_diary
 		visit '/update.rb?conf=referer'
 		fill_in 'referer_table', with: <<-REFERER

--- a/spec/acceptance/view_comment_spec.rb
+++ b/spec/acceptance/view_comment_spec.rb
@@ -20,7 +20,7 @@ feature 'ツッコミの表示' do
 		expect(page).to have_no_content "こんにちは!こんにちは!"
 	end
 
-	scenario "日付表示だと絵文字を表示できる", :exclude_selenium do
+	scenario "日付表示だと絵文字を表示できる", :exclude_webrick do
 		append_default_diary
 
 		visit "/"
@@ -39,7 +39,7 @@ BODY
 		}
 	end
 
-	scenario "一覧表示でも絵文字を表示できる", :exclude_selenium do
+	scenario "一覧表示でも絵文字を表示できる", :exclude_webrick do
 		append_default_diary
 
 		visit "/"

--- a/spec/acceptance/view_diary_spec.rb
+++ b/spec/acceptance/view_diary_spec.rb
@@ -10,7 +10,7 @@ feature '日記を読む' do
 		expect(page).to have_css('a[href="update.rb?conf=default"]')
 	end
 
-	scenario 'RackアプリではCSSとJavaScriptがassets配下から配信される', :exclude_selenium do
+	scenario 'RackアプリではCSSとJavaScriptがassets配下から配信される', :exclude_webrick do
 		visit '/'
 		stylesheet_hrefs = page.all('link[rel=stylesheet]', visible: false).map {|link| link[:href] }
 		expect(stylesheet_hrefs).not_to be_empty

--- a/spec/acceptance/view_referer_spec.rb
+++ b/spec/acceptance/view_referer_spec.rb
@@ -1,6 +1,6 @@
 require 'acceptance_helper'
 
-feature 'リンク元の表示', exclude_selenium: true do
+feature 'リンク元の表示', exclude_webrick: true do
 	scenario '日表示にリンク元が表示されている' do
 		append_default_diary
 		visit '/'

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -51,13 +51,21 @@ RSpec.configure do |config|
 	end
 
 	if ENV['TEST_MODE'] == 'webrick'
-		Capybara.default_driver = :selenium
-		Capybara.app_host = 'http://localhost:' + (ENV['PORT'] || '19292')
+		require 'capybara/cuprite'
+		Capybara.register_driver(:cuprite) do |app|
+			Capybara::Cuprite::Driver.new(app, window_size: [1024, 768])
+		end
+		Capybara.default_driver = :cuprite
+		# The CGI server under test is started separately by `rake server`.
+		Capybara.run_server = false
+		# Not 'localhost': Chrome resolves it to ::1, and the spam filter specs
+		# expect REMOTE_ADDR to be 127.0.0.1.
+		Capybara.app_host = 'http://127.0.0.1:' + (ENV['PORT'] || '19292')
 	end
 
 	excludes = case ENV['TEST_MODE']
 				  when 'webrick'
-					  [:exclude_selenium]
+					  [:exclude_webrick]
 				  else # rack
 					  [:exclude_rack]
 				  end


### PR DESCRIPTION
`selenium-webdriver` keeps breaking the build. 4.45 requires Ruby 3.3 while the CI matrix still covers 3.1, and the `< 4.45` pin that works around it resolves back to 2.27.2, which fails on `require "zip/zip"`. That is where #1364 is stuck. Cuprite speaks CDP directly, so no driver binary has to stay in sync with Chrome, and `ferrum` requires Ruby 3.1, matching our matrix floor.

`TEST_MODE=webrick` also had not been runnable for a while. Capybara booted its own server for `Capybara.app` and died with a `LoadError` for `puma`, so every example failed before reaching a browser. `Capybara.run_server = false` makes it use the server `rake server` provides. The host is now `127.0.0.1` because Chrome resolves `localhost` to `::1` and the spam filter specs assert `REMOTE_ADDR` is `127.0.0.1`.

`rake spec` matches `master` locally. I could not run `TEST_MODE=webrick` end to end because its CGI child activates the default `cgi` gem before `bundler/setup`, which happens on `master` too, so I verified Cuprite against a Rack-served instance instead.
