### PR TITLE
Make the standalone CGI server usable again

### DIFF
--- a/lib/tdiary.rb
+++ b/lib/tdiary.rb
@@ -16,6 +16,12 @@ $:.unshift File.join(File::dirname(__FILE__), '../misc/lib')
 	Dir[File.join(File.dirname(__FILE__), path)].each {|dir| $:.unshift dir }
 end
 
+# Set up the bundle before requiring anything that ships as a default gem.
+# A CGI process starts without RUBYOPT or BUNDLE_GEMFILE (WEBrick's CGI runner
+# wipes the environment), so requiring 'cgi' first activates the version bundled
+# with Ruby and Bundler then fails on the version the Gemfile asks for.
+require 'tdiary/environment'
+
 gem 'cgi' if RUBY_VERSION >= '4.0'
 require 'cgi'
 require 'uri'
@@ -23,7 +29,6 @@ require 'fileutils'
 require 'pstore'
 require 'json'
 require 'erb'
-require 'tdiary/environment'
 require 'tdiary/core_ext'
 
 #

--- a/lib/tdiary/server.rb
+++ b/lib/tdiary/server.rb
@@ -12,6 +12,28 @@ module TDiary
 		require 'webrick/accesslog'
 		require 'tempfile'
 
+		# WEBrick's CGI runner clears the environment of the CGI child process
+		# before exec'ing it, so the child cannot find the gems the server itself
+		# runs with. Hand the RubyGems and Bundler locations back to it.
+		module CGIEnvironment
+			def meta_vars
+				super.merge( {
+					'HOME' => ENV['HOME'],
+					'GEM_HOME' => Gem.dir,
+					'GEM_PATH' => Gem.path.join( File::PATH_SEPARATOR ),
+					'BUNDLE_GEMFILE' => ENV['BUNDLE_GEMFILE'],
+				}.compact )
+			end
+		end
+
+		class CGIHandler < WEBrick::HTTPServlet::CGIHandler
+			def do_GET( req, res )
+				req.extend( CGIEnvironment )
+				super
+			end
+			alias do_POST do_GET
+		end
+
 		class << self
 			def run( option )
 				@@server = new( option )
@@ -38,9 +60,9 @@ module TDiary
 				CGIInterpreter: WEBrick::HTTPServlet::CGIHandler::Ruby
 			)
 			@server.logger.level = WEBrick::Log::DEBUG
-			@server.mount("/", WEBrick::HTTPServlet::CGIHandler, TDiary.root + "/index.rb")
-			@server.mount("/index.rb", WEBrick::HTTPServlet::CGIHandler, TDiary.root + '/index.rb')
-			@server.mount("/update.rb", WEBrick::HTTPServlet::CGIHandler, TDiary.root + "/update.rb")
+			@server.mount("/", CGIHandler, TDiary.root + "/index.rb")
+			@server.mount("/index.rb", CGIHandler, TDiary.root + '/index.rb')
+			@server.mount("/update.rb", CGIHandler, TDiary.root + "/update.rb")
 			@server.mount("/theme", WEBrick::HTTPServlet::FileHandler, TDiary.root + '/theme')
 			@server.mount("/js", WEBrick::HTTPServlet::FileHandler, TDiary.root + '/js')
 		end


### PR DESCRIPTION
Every request under `rake server` returned a 500 page. WEBrick's CGI runner clears the environment before exec'ing the child, so the CGI process starts without the gem locations the server itself runs with. It could not find the bundle at all. Where it could, as in a vendored tarball install, `lib/tdiary.rb` had already activated Ruby's own `cgi` by the time `tdiary/environment` reached `bundler/setup`, and Bundler then failed on the version `Gemfile.lock` asks for.

`tdiary/environment` now loads ahead of any default gem, and `TDiary::Server` hands `HOME`, `GEM_HOME`, `GEM_PATH` and `BUNDLE_GEMFILE` to the child through the CGI meta variables.

`rake spec` and `rake test` are unchanged. `TEST_MODE=webrick rspec spec/acceptance` reaches the end now, though 11 of its 27 examples still fail, mostly on `Ferrum::TimeoutError` because every CGI process loads the whole development group.
