### PR TITLE
Report uncaught exceptions to rack.errors

### DIFF
--- a/lib/tdiary/application.rb
+++ b/lib/tdiary/application.rb
@@ -15,6 +15,7 @@ module TDiary
 			base_dir ||= self.base_dir
 
 			@app = ::Rack::Builder.app do
+				use TDiary::Rack::ErrorHandler
 				map base_dir do
 					map '/' do
 						use TDiary::Rack::HtmlAnchor
@@ -39,13 +40,7 @@ module TDiary
 		end
 
 		def call( env )
-			begin
-				@app.call( env )
-			rescue Exception => e
-				body = ["#{e.class}: #{e}\n"]
-				body << e.backtrace.join("\n")
-				[500, {'content-type' => 'text/plain'}, body]
-			end
+			@app.call( env )
 		end
 
 		def assets_paths

--- a/lib/tdiary/cgi_adapter.rb
+++ b/lib/tdiary/cgi_adapter.rb
@@ -1,4 +1,5 @@
 require 'stringio'
+require 'tdiary/rack/error_handler'
 
 module TDiary
 	#
@@ -23,9 +24,10 @@ module TDiary
 
 			def run( request, dispatcher )
 				env = build_env( request.env.to_hash, request.in, request.err )
-				write_response( request.out, *dispatcher.call( env ) )
+				app = TDiary::Rack::ErrorHandler.new( dispatcher )
+				write_response( request.out, *app.call( env ) )
 			rescue Exception => e
-				write_error( request.out, e )
+				write_error( request, e )
 			ensure
 				request.finish
 			end
@@ -69,9 +71,9 @@ module TDiary
 				end
 			end
 
-			def write_error( out, e )
-				body = "<h1>500 Internal Server Error</h1>\n<pre>#{CGI::escapeHTML( "#{e} (#{e.class})\n\n#{e.backtrace.join( "\n" )}" )}</pre>\n"
-				write_response( out, 500, { 'content-type' => 'text/html' }, [body] )
+			def write_error( request, e )
+				TDiary::Rack::ErrorHandler.report( request.err, e )
+				write_response( request.out, 500, { 'content-type' => 'text/plain' }, ["500 Internal Server Error\n"] )
 			end
 		end
 	end

--- a/lib/tdiary/rack.rb
+++ b/lib/tdiary/rack.rb
@@ -1,5 +1,6 @@
 module TDiary
 	module Rack
+		autoload :ErrorHandler,     'tdiary/rack/error_handler'
 		autoload :HtmlAnchor,       'tdiary/rack/html_anchor'
 		autoload :ValidRequestPath, 'tdiary/rack/valid_request_path'
 		autoload :Session,          'tdiary/rack/session'

--- a/lib/tdiary/rack/error_handler.rb
+++ b/lib/tdiary/rack/error_handler.rb
@@ -1,0 +1,36 @@
+module TDiary
+	module Rack
+		#
+		# class ErrorHandler
+		#  catches exceptions leaked from the downstream app, reports the
+		#  class, message and backtrace to rack.errors, and replaces the
+		#  response with a plain 500 that does not expose the details to
+		#  the client.
+		#
+		class ErrorHandler
+			def initialize( app )
+				@app = app
+			end
+
+			def call( env )
+				@app.call( env )
+			rescue Exception => e
+				self.class.report( env['rack.errors'], e )
+				[500, { 'content-type' => 'text/plain' }, ["500 Internal Server Error\n"]]
+			end
+
+			def self.report( errors, e )
+				errors.puts "#{e.class}: #{e.message}"
+				( e.backtrace || [] ).each {|line| errors.puts "\t#{line}" }
+				errors.flush
+			end
+		end
+	end
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:

--- a/spec/core/application_spec.rb
+++ b/spec/core/application_spec.rb
@@ -52,14 +52,17 @@ describe TDiary::Application do
 		context "when the application raises exception" do
 			before do
 				allow(TDiary::Dispatcher).to receive_message_chain(:index).and_return(
-					lambda {|env| raise StandardError.new }
+					lambda {|env| raise StandardError.new('boom') }
 				)
 			end
 
-			it do
-				get '/'
+			let(:errors) { StringIO.new }
+
+			it 'returns a plain 500 and reports the exception to rack.errors' do
+				get '/', {}, 'rack.errors' => errors
 				expect(last_response.status).to eq 500
-				expect(last_response.body).to match(/^StandardError/)
+				expect(last_response.body).not_to include 'StandardError'
+				expect(errors.string).to match(/^StandardError: boom$/)
 			end
 		end
 	end

--- a/spec/core/cgi_adapter_spec.rb
+++ b/spec/core/cgi_adapter_spec.rb
@@ -152,14 +152,26 @@ describe TDiary::CGIAdapter do
 			expect( request ).to be_finished
 		end
 
-		it 'writes a 500 response and finishes the request when dispatch raises' do
+		it 'writes a plain 500 and reports to the error stream when dispatch raises' do
 			request = MockFCGIRequest.new( fcgi_env )
 			dispatcher = lambda {|env| raise 'boom' }
 
 			described_class.run( request, dispatcher )
 
 			expect( request.out.string ).to start_with "Status: 500\r\n"
-			expect( request.out.string ).to include 'boom'
+			expect( request.out.string ).not_to include 'boom'
+			expect( request.err.string ).to match( /^RuntimeError: boom$/ )
+			expect( request ).to be_finished
+		end
+
+		it 'writes a plain 500 and reports to the error stream when the env cannot be built' do
+			request = MockFCGIRequest.new( nil )
+			dispatcher = lambda {|env| [200, {}, []] }
+
+			described_class.run( request, dispatcher )
+
+			expect( request.out.string ).to start_with "Status: 500\r\n"
+			expect( request.err.string ).to match( /^NoMethodError: / )
 			expect( request ).to be_finished
 		end
 	end

--- a/spec/core/rack/error_handler_spec.rb
+++ b/spec/core/rack/error_handler_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'rack/test'
+require 'stringio'
+require 'tdiary/rack/error_handler'
+
+describe TDiary::Rack::ErrorHandler do
+	include Rack::Test::Methods
+
+	describe 'when the app succeeds' do
+		let(:app) { TDiary::Rack::ErrorHandler.new(
+			lambda{|env| [200, {'content-type' => 'text/plain'}, ['Awesome']]} )}
+
+		it 'passes the response through' do
+			get '/'
+			expect(last_response.status).to eq 200
+			expect(last_response.body).to eq 'Awesome'
+		end
+	end
+
+	describe 'when the app raises' do
+		let(:app) { TDiary::Rack::ErrorHandler.new(
+			lambda{|env| raise StandardError, 'boom'} )}
+		let(:errors) { StringIO.new }
+
+		it 'returns a plain 500 without the exception details' do
+			get '/', {}, 'rack.errors' => errors
+			expect(last_response.status).to eq 500
+			expect(last_response.headers['content-type']).to eq 'text/plain'
+			expect(last_response.body).to eq "500 Internal Server Error\n"
+		end
+
+		it 'reports the class, message and backtrace to rack.errors' do
+			get '/', {}, 'rack.errors' => errors
+			expect(errors.string).to match(/^StandardError: boom$/)
+			expect(errors.string).to include __FILE__
+		end
+	end
+
+	describe 'when the app raises a non-StandardError exception' do
+		let(:app) { TDiary::Rack::ErrorHandler.new(
+			lambda{|env| raise Exception, 'fatal'} )}
+		let(:errors) { StringIO.new }
+
+		it 'catches it too' do
+			get '/', {}, 'rack.errors' => errors
+			expect(last_response.status).to eq 500
+			expect(errors.string).to match(/^Exception: fatal$/)
+		end
+	end
+end


### PR DESCRIPTION
Uncaught exceptions during request processing were swallowed with a bare 500, so nothing reached the web server's error log (Apache showed no trace of the failure). This adds `TDiary::Rack::ErrorHandler`, which reports the exception class, message and backtrace to `rack.errors` and returns a plain 500 without the details. `Application#call` uses it via `Rack::Builder`, and `CGIAdapter` wraps the dispatcher with it, so all three hosting paths (Rack, CGI, FastCGI) log the same way. The CGI/FCGI error page no longer embeds the backtrace in HTML.

Phase 6b originally considered standard middleware, but I keep the current code instead: `Rack::ETag` skips responses with `last-modified` and emits weak ETags, `Rack::Head` would lose the render-skipping HEAD optimization, and `Rack::ConditionalGet` adds an `If-Modified-Since` 304 path that can miss plugin output changes.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
