### PR TITLE
Add security headers at the Dispatcher level

### DIFF
--- a/lib/tdiary/configuration.rb
+++ b/lib/tdiary/configuration.rb
@@ -87,6 +87,7 @@ module TDiary
 				:tdiary_version,
 				:html_title, :author_name, :author_mail, :index_page, :hour_offset,
 				:description, :icon, :banner, :x_frame_options,
+				:referrer_policy, :hsts,
 				:header, :footer,
 				:section_anchor, :comment_anchor, :date_format, :latest_limit, :show_nyear,
 				:theme, :css,
@@ -155,6 +156,9 @@ module TDiary
 
 			@html_title = '' unless @html_title
 			@x_frame_options = nil unless @x_frame_options
+			@referrer_policy = 'strict-origin-when-cross-origin' unless @referrer_policy
+			@hsts = nil unless @hsts
+			@hsts = 'max-age=31536000' if @hsts == true
 			@header = '' unless @header
 			@footer = '' unless @footer
 

--- a/lib/tdiary/dispatcher.rb
+++ b/lib/tdiary/dispatcher.rb
@@ -17,7 +17,10 @@ module TDiary
 
 		def call( env )
 			request = adopt_rack_request_to_plain_old_tdiary_style( env )
-			@target.run( request ).to_a
+			main = @target.new( request )
+			response = main.run
+			apply_security_headers( response )
+			response.to_a
 		end
 
 		class << self
@@ -33,6 +36,10 @@ module TDiary
 		end
 
 	private
+
+		def apply_security_headers( response )
+			response.set_header( 'x-content-type-options', 'nosniff' )
+		end
 
 		def adopt_rack_request_to_plain_old_tdiary_style( env )
 			# rebuffer rack.input into a rewindable StringIO; both

--- a/lib/tdiary/dispatcher.rb
+++ b/lib/tdiary/dispatcher.rb
@@ -19,7 +19,7 @@ module TDiary
 			request = adopt_rack_request_to_plain_old_tdiary_style( env )
 			main = @target.new( request )
 			response = main.run
-			apply_security_headers( response, main.conf )
+			apply_security_headers( response, request, main.conf )
 			response.to_a
 		end
 
@@ -37,9 +37,11 @@ module TDiary
 
 	private
 
-		def apply_security_headers( response, conf )
+		def apply_security_headers( response, request, conf )
 			response.set_header( 'x-content-type-options', 'nosniff' )
 			apply_frame_restrictions( response, conf )
+			response.set_header( 'referrer-policy', conf.referrer_policy ) if conf.referrer_policy
+			response.set_header( 'strict-transport-security', conf.hsts ) if conf.hsts && request.ssl?
 		end
 
 		# The update target is an authenticated admin UI and always forbids

--- a/lib/tdiary/dispatcher.rb
+++ b/lib/tdiary/dispatcher.rb
@@ -19,7 +19,7 @@ module TDiary
 			request = adopt_rack_request_to_plain_old_tdiary_style( env )
 			main = @target.new( request )
 			response = main.run
-			apply_security_headers( response )
+			apply_security_headers( response, main.conf )
 			response.to_a
 		end
 
@@ -37,8 +37,27 @@ module TDiary
 
 	private
 
-		def apply_security_headers( response )
+		def apply_security_headers( response, conf )
 			response.set_header( 'x-content-type-options', 'nosniff' )
+			apply_frame_restrictions( response, conf )
+		end
+
+		# The update target is an authenticated admin UI and always forbids
+		# cross-origin framing; the index target follows conf.x_frame_options.
+		# CSP frame-ancestors is the standard control, X-Frame-Options is kept
+		# alongside for legacy user agents.
+		def apply_frame_restrictions( response, conf )
+			if @target == UpdateMain
+				response.set_header( 'content-security-policy', "frame-ancestors 'self'" )
+				response.set_header( 'x-frame-options', 'SAMEORIGIN' )
+			elsif conf.x_frame_options
+				ancestors = case conf.x_frame_options.upcase
+								when 'SAMEORIGIN' then "'self'"
+								when 'DENY' then "'none'"
+								end
+				response.set_header( 'content-security-policy', "frame-ancestors #{ancestors}" ) if ancestors
+				response.set_header( 'x-frame-options', conf.x_frame_options )
+			end
 		end
 
 		def adopt_rack_request_to_plain_old_tdiary_style( env )

--- a/lib/tdiary/dispatcher/index_main.rb
+++ b/lib/tdiary/dispatcher/index_main.rb
@@ -40,7 +40,6 @@ module TDiary
 								head['content-length'] = body.bytesize.to_s
 							end
 							head['cache-control'] = 'no-cache'
-							head['x-frame-options'] = conf.x_frame_options if conf.x_frame_options
 							res = TDiary::Response.new( body, status, head )
 							res.set_header('Set-Cookie', tdiary.cookies.map(&:to_s)) if tdiary && tdiary.cookies.size > 0
 							res

--- a/lib/tdiary/dispatcher/update_main.rb
+++ b/lib/tdiary/dispatcher/update_main.rb
@@ -22,8 +22,7 @@ module TDiary
 					head = {
 						'content-type' => 'text/html; charset=UTF-8',
 						'content-length' => body.bytesize.to_s,
-						'vary' => 'User-Agent',
-						'x-frame-options' => 'SAMEORIGIN'
+						'vary' => 'User-Agent'
 					}
 					body = ( request.head? ? '' : body )
 					TDiary::Response.new( body, 200, head )

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -748,6 +748,10 @@ def saveconf_default
 		@conf['base_url'] = @cgi.params['base_url'][0]
 		@conf.x_frame_options = @cgi.params['x_frame_options'][0]
 		@conf.x_frame_options = nil if @conf.x_frame_options.empty?
+		@conf.referrer_policy = @cgi.params['referrer_policy'][0]
+		@conf.referrer_policy = nil if @conf.referrer_policy.empty?
+		@conf.hsts = @cgi.params['hsts'][0]
+		@conf.hsts = nil if @conf.hsts.empty?
 	end
 end
 

--- a/lib/tdiary/plugin/en/00default.rb
+++ b/lib/tdiary/plugin/en/00default.rb
@@ -169,6 +169,21 @@ add_conf_proc( 'default', 'Site information', 'basic' ) do
 		<option value="SAMEORIGIN"#{" selected" if @conf.x_frame_options == 'SAMEORIGIN'}>Permit in same domain</option>
 		<option value="DENY"#{" selected" if @conf.x_frame_options == 'DENY'}>Deny</option>
 	</select></p>
+
+	<h3 class="subtitle">Referrer Policy</h3>
+	<p>Controls how much referrer information the browser sends when following links from your diary to other sites. The default matches the browser's standard behavior.</p>
+	<p><select name="referrer_policy">
+		<option value="strict-origin-when-cross-origin"#{" selected" if @conf.referrer_policy == 'strict-origin-when-cross-origin'}>Send origin only to other sites (default)</option>
+		<option value="same-origin"#{" selected" if @conf.referrer_policy == 'same-origin'}>Do not send to other sites</option>
+		<option value="no-referrer"#{" selected" if @conf.referrer_policy == 'no-referrer'}>Never send</option>
+	</select></p>
+
+	<h3 class="subtitle">Force HTTPS (HSTS)</h3>
+	<p>Sends the Strict-Transport-Security header on HTTPS responses so browsers keep using HTTPS afterwards. Leave disabled if your site is served over HTTP.</p>
+	<p><select name="hsts">
+		<option value=""#{" selected" unless @conf.hsts}>Disabled</option>
+		<option value="max-age=31536000"#{" selected" if @conf.hsts == 'max-age=31536000'}>Enabled (1 year)</option>
+	</select></p>
 	HTML
 end
 

--- a/lib/tdiary/plugin/ja/00default.rb
+++ b/lib/tdiary/plugin/ja/00default.rb
@@ -196,6 +196,21 @@ add_conf_proc( 'default', 'サイトの情報', 'basic' ) do
 		<option value="SAMEORIGIN"#{" selected" if @conf.x_frame_options == 'SAMEORIGIN'}>同一ドメインなら許可する</option>
 		<option value="DENY"#{" selected" if @conf.x_frame_options == 'DENY'}>禁止する</option>
 	</select></p>
+
+	<h3 class="subtitle">Referrerポリシー</h3>
+	<p>日記内のリンクをたどって他のサイトへ移動するときに、ブラウザが送信するReferrerの範囲を指定します。標準の設定はブラウザの既定動作と同じです。</p>
+	<p><select name="referrer_policy">
+		<option value="strict-origin-when-cross-origin"#{" selected" if @conf.referrer_policy == 'strict-origin-when-cross-origin'}>他サイトへはURLの先頭部分のみ送信する(標準)</option>
+		<option value="same-origin"#{" selected" if @conf.referrer_policy == 'same-origin'}>他サイトへは送信しない</option>
+		<option value="no-referrer"#{" selected" if @conf.referrer_policy == 'no-referrer'}>常に送信しない</option>
+	</select></p>
+
+	<h3 class="subtitle">HTTPSの強制(HSTS)</h3>
+	<p>HTTPSでアクセスされたときに、以後もHTTPSの使用をブラウザに強制するStrict-Transport-Securityヘッダを送出します。HTTPで運用しているサイトでは無効のままにしてください。</p>
+	<p><select name="hsts">
+		<option value=""#{" selected" unless @conf.hsts}>無効</option>
+		<option value="max-age=31536000"#{" selected" if @conf.hsts == 'max-age=31536000'}>有効(期間1年)</option>
+	</select></p>
 	HTML
 end
 

--- a/spec/core/dispatcher_security_headers_spec.rb
+++ b/spec/core/dispatcher_security_headers_spec.rb
@@ -62,6 +62,41 @@ describe 'security headers of the dispatcher' do
 			expect(last_response.headers['x-content-type-options']).to eq 'nosniff'
 		end
 	end
+
+	describe 'frame embedding control' do
+		it 'restricts the update response to same-origin framing' do
+			get '/update.rb'
+			expect(last_response.headers['content-security-policy']).to eq "frame-ancestors 'self'"
+			expect(last_response.headers['x-frame-options']).to eq 'SAMEORIGIN'
+		end
+
+		it 'leaves the index response unrestricted by default' do
+			get '/'
+			expect(last_response.headers['content-security-policy']).to be_nil
+			expect(last_response.headers['x-frame-options']).to be_nil
+		end
+
+		it 'maps x_frame_options SAMEORIGIN to frame-ancestors self on the index response' do
+			write_data_conf "x_frame_options = 'SAMEORIGIN'"
+			get '/'
+			expect(last_response.headers['content-security-policy']).to eq "frame-ancestors 'self'"
+			expect(last_response.headers['x-frame-options']).to eq 'SAMEORIGIN'
+		end
+
+		it 'maps x_frame_options DENY to frame-ancestors none on the index response' do
+			write_data_conf "x_frame_options = 'DENY'"
+			get '/'
+			expect(last_response.headers['content-security-policy']).to eq "frame-ancestors 'none'"
+			expect(last_response.headers['x-frame-options']).to eq 'DENY'
+		end
+
+		it 'passes an unmappable x_frame_options value through without CSP' do
+			write_data_conf "x_frame_options = 'ALLOW-FROM https://example.net/'"
+			get '/'
+			expect(last_response.headers['content-security-policy']).to be_nil
+			expect(last_response.headers['x-frame-options']).to eq 'ALLOW-FROM https://example.net/'
+		end
+	end
 end
 
 # Local Variables:

--- a/spec/core/dispatcher_security_headers_spec.rb
+++ b/spec/core/dispatcher_security_headers_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'rack/test'
+require 'rack/lint'
+require 'tdiary/application'
+
+# Locks the security headers injected by TDiary::Dispatcher, which is
+# shared by all the hosting paths (Rack, CGI and FCGI).
+describe 'security headers of the dispatcher' do
+	include Rack::Test::Methods
+
+	def app
+		@app ||= Rack::Builder.new do
+			map '/update.rb' do
+				use Rack::Lint
+				run TDiary::Dispatcher.update
+			end
+
+			map '/' do
+				use Rack::Lint
+				run TDiary::Dispatcher.index
+			end
+		end
+	end
+
+	let(:fixture_conf) { File.expand_path('../../fixtures/just_installed.conf', __FILE__) }
+	let(:work_conf) { File.expand_path('../../../tdiary.conf', __FILE__) }
+	let(:work_data_dir) { File.expand_path('../../../tmp/data', __FILE__) }
+
+	def write_data_conf( extra = '' )
+		File.write File.join(work_data_dir, 'tdiary.conf'), File.read(fixture_conf) + "\n" + extra
+	end
+
+	before do
+		FileUtils.cp_r File.expand_path('../../fixtures/tdiary.conf.rack', __FILE__), work_conf
+		FileUtils.mkdir_p work_data_dir
+		write_data_conf
+	end
+
+	after do
+		FileUtils.rm_rf work_data_dir
+		FileUtils.rm_f work_conf
+	end
+
+	describe 'X-Content-Type-Options' do
+		it 'is nosniff on the index response' do
+			get '/'
+			expect(last_response.status).to eq 200
+			expect(last_response.headers['x-content-type-options']).to eq 'nosniff'
+		end
+
+		it 'is nosniff on the update response' do
+			get '/update.rb'
+			expect(last_response.status).to eq 200
+			expect(last_response.headers['x-content-type-options']).to eq 'nosniff'
+		end
+
+		it 'is nosniff on a 304 response' do
+			get '/'
+			etag = last_response.headers['etag']
+			get '/', {}, { 'HTTP_IF_NONE_MATCH' => etag }
+			expect(last_response.status).to eq 304
+			expect(last_response.headers['x-content-type-options']).to eq 'nosniff'
+		end
+	end
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:
+# vim: ts=3

--- a/spec/core/dispatcher_security_headers_spec.rb
+++ b/spec/core/dispatcher_security_headers_spec.rb
@@ -97,6 +97,44 @@ describe 'security headers of the dispatcher' do
 			expect(last_response.headers['x-frame-options']).to eq 'ALLOW-FROM https://example.net/'
 		end
 	end
+
+	describe 'Referrer-Policy' do
+		it 'defaults to strict-origin-when-cross-origin' do
+			get '/'
+			expect(last_response.headers['referrer-policy']).to eq 'strict-origin-when-cross-origin'
+		end
+
+		it 'follows conf.referrer_policy' do
+			write_data_conf "referrer_policy = 'no-referrer'"
+			get '/'
+			expect(last_response.headers['referrer-policy']).to eq 'no-referrer'
+		end
+	end
+
+	describe 'Strict-Transport-Security' do
+		it 'is absent by default even on HTTPS' do
+			get 'https://www.example.org/'
+			expect(last_response.headers['strict-transport-security']).to be_nil
+		end
+
+		it 'is sent on HTTPS when conf.hsts is set' do
+			write_data_conf "hsts = 'max-age=63072000; includeSubDomains'"
+			get 'https://www.example.org/'
+			expect(last_response.headers['strict-transport-security']).to eq 'max-age=63072000; includeSubDomains'
+		end
+
+		it 'maps conf.hsts = true to a one year max-age' do
+			write_data_conf "hsts = true"
+			get 'https://www.example.org/'
+			expect(last_response.headers['strict-transport-security']).to eq 'max-age=31536000'
+		end
+
+		it 'is not sent on plain HTTP even when conf.hsts is set' do
+			write_data_conf "hsts = true"
+			get '/'
+			expect(last_response.headers['strict-transport-security']).to be_nil
+		end
+	end
 end
 
 # Local Variables:

--- a/views/tdiary.rconf
+++ b/views/tdiary.rconf
@@ -17,6 +17,8 @@ description = <%= (@description || '' ).force_encoding('ASCII-8BIT').dump %>
 icon = <%= (@icon || '').force_encoding('ASCII-8BIT').dump %>
 banner = <%= (@banner || '').force_encoding('ASCII-8BIT').dump %>
 x_frame_options = <%= @x_frame_options ? @x_frame_options.force_encoding('ASCII-8BIT').dump : 'nil' %>
+referrer_policy = <%= @referrer_policy ? @referrer_policy.force_encoding('ASCII-8BIT').dump : 'nil' %>
+hsts = <%= @hsts ? @hsts.force_encoding('ASCII-8BIT').dump : 'nil' %>
 
 #
 # header / footer


### PR DESCRIPTION
Adds security headers at the Dispatcher level so the Rack, CGI and FCGI paths all get them.

Headers:

- `X-Content-Type-Options: nosniff` on every response, unconditional.
- `Content-Security-Policy: frame-ancestors 'self'` plus `X-Frame-Options: SAMEORIGIN` on every update (admin UI) response. Previously `SAMEORIGIN` was hardcoded in `UpdateMain` only for the 200 path.
- Index responses follow `x_frame_options` as before, now also emitting the CSP equivalent: `SAMEORIGIN` maps to `'self'`, `DENY` to `'none'`, other values pass through as `X-Frame-Options` only. Existing configurations keep working unchanged; `X-Frame-Options` stays alongside CSP for legacy user agents.
- `Referrer-Policy`: new `referrer_policy` conf option, default `strict-origin-when-cross-origin` (same as the browser default, so same-origin Referer and `csrf_check` are unaffected). Stricter values selectable in the basic preferences.
- `Strict-Transport-Security`: new `hsts` conf option, off by default, sent on HTTPS responses only. `hsts = true` maps to `max-age=31536000`.

Existing specs needed no updates; new headers are covered by `spec/core/dispatcher_security_headers_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
