### PR TITLE
Validate Origin and Sec-Fetch-Site first in csrf_check

### DIFF
--- a/lib/tdiary/author_only_base.rb
+++ b/lib/tdiary/author_only_base.rb
@@ -6,6 +6,17 @@ module TDiary
 	class TDiaryAuthorOnlyBase < TDiaryBase
 		def csrf_protection_get_is_okay; false; end
 
+		# pure decision helper for csrf_check, a class method so unit specs
+		# can exercise it without building a full TDiaryBase
+		#
+		# referer must be non-empty with its query string stripped; it is
+		# allowed when it names the update page itself or matches the
+		# admin-configured regexp
+		def self.csrf_referer_allowed?( referer, config_uri, allowed_referer_regexp )
+			return true if config_uri == URI.parse( referer )
+			allowed_referer_regexp != '' && Regexp.new( allowed_referer_regexp ).match?( referer )
+		end
+
 		def initialize( cgi, rhtml, conf )
 			super
 			csrf_check( @request, conf )
@@ -43,8 +54,7 @@ module TDiary
 
 			referer_is_empty = referer == ''
 			referer_uri = URI.parse(referer) if !referer_is_empty
-			referer_is_config = !referer_is_empty && config_uri == referer_uri
-			referer_is_config ||= Regexp.new(updaterb_regexp) =~ referer if !referer_is_empty && updaterb_regexp != ''
+			referer_is_config = !referer_is_empty && self.class.csrf_referer_allowed?(referer, config_uri, updaterb_regexp)
 			is_post = request.post?
 
 			given_key = request.params['csrf_protection_key']

--- a/lib/tdiary/author_only_base.rb
+++ b/lib/tdiary/author_only_base.rb
@@ -6,15 +6,66 @@ module TDiary
 	class TDiaryAuthorOnlyBase < TDiaryBase
 		def csrf_protection_get_is_okay; false; end
 
-		# pure decision helper for csrf_check, a class method so unit specs
-		# can exercise it without building a full TDiaryBase
-		#
+		# pure decision helpers for csrf_check, class methods so unit specs
+		# can exercise them without building a full TDiaryBase
+
 		# referer must be non-empty with its query string stripped; it is
 		# allowed when it names the update page itself or matches the
 		# admin-configured regexp
 		def self.csrf_referer_allowed?( referer, config_uri, allowed_referer_regexp )
 			return true if config_uri == URI.parse( referer )
 			allowed_referer_regexp != '' && Regexp.new( allowed_referer_regexp ).match?( referer )
+		end
+
+		# normalize an absolute http(s) URL to its origin serialization
+		# (lowercase scheme://host, default port omitted); nil when the
+		# input has no usable origin
+		def self.csrf_origin_of( url )
+			uri = URI.parse( url.to_s )
+			return nil unless uri.kind_of?( URI::HTTP ) and uri.host
+			port = uri.port == uri.default_port ? '' : ":#{uri.port}"
+			"#{uri.scheme.downcase}://#{uri.host.downcase}#{port}"
+		rescue URI::InvalidURIError
+			nil
+		end
+
+		# classify the request provenance from browser fetch metadata:
+		# :same_origin / :cross_site / :unknown (no usable signal, e.g.
+		# non-browser clients or a user-initiated navigation)
+		def self.csrf_fetch_verdict( origin, sec_fetch_site, allowed_origins )
+			if origin and !origin.empty?
+				# 'null' (sandboxed or opaque initiators) never matches
+				return allowed_origins.include?( origin.downcase ) ? :same_origin : :cross_site
+			end
+			case sec_fetch_site
+			when 'same-origin'
+				:same_origin
+			when 'same-site', 'cross-site'
+				:cross_site
+			else
+				:unknown
+			end
+		end
+
+		# main csrf decision: Origin / Sec-Fetch-Site first, the legacy
+		# Referer check only as a fallback when neither header gives a
+		# usable signal. A cross-site verdict can still be allowed by an
+		# explicit Referer allowance (the update page itself or the
+		# admin-configured regexp), but not by the empty-referer tolerance
+		# of check_referer=false.
+		def self.csrf_provenance_ok?( origin, sec_fetch_site, referer, allowed_origins, config_uri, allowed_referer_regexp, check_referer )
+			case csrf_fetch_verdict( origin, sec_fetch_site, allowed_origins )
+			when :same_origin
+				true
+			when :cross_site
+				referer != '' && csrf_referer_allowed?( referer, config_uri, allowed_referer_regexp )
+			else
+				if referer == ''
+					!check_referer
+				else
+					csrf_referer_allowed?( referer, config_uri, allowed_referer_regexp )
+				end
+			end
 		end
 
 		def initialize( cgi, rhtml, conf )
@@ -63,12 +114,18 @@ module TDiary
 			is_key_ok = masterkey != '' && given_key == masterkey
 
 			keycheck_ok = !check_key || is_key_ok
-			referercheck_ok = referer_is_config || (!check_referer && referer_is_empty)
+
+			origin = request.env['HTTP_ORIGIN']
+			sec_fetch_site = request.env['HTTP_SEC_FETCH_SITE']
+			allowed_origins = [base_uri, config_uri, request.base_url].map {|url|
+				self.class.csrf_origin_of( url )
+			}.compact.uniq
+			provenance_ok = self.class.csrf_provenance_ok?( origin, sec_fetch_site, referer, allowed_origins, config_uri, updaterb_regexp, check_referer )
 
 			if csrf_protection_get_is_okay then
 				return if is_post || given_key == nil
 			else
-				return if keycheck_ok && referercheck_ok
+				return if keycheck_ok && provenance_ok
 			end
 
 			raise Exception.new(<<"EOS")
@@ -79,6 +136,8 @@ Security Error: Possible Cross-site Request Forgery (CSRF)
                 - Mode is #{ self.mode || 'unknown' }
                     - GET is #{ csrf_protection_get_is_okay ? '' : 'not '}allowed
                 - Request Method is #{ is_post ? 'POST' : 'not POST' }
+                - Origin is #{ origin ? h(origin) : 'nothing' }
+                - Sec-Fetch-Site is #{ sec_fetch_site ? h(sec_fetch_site) : 'nothing' }
                 - Referer is #{ referer_is_empty ? 'empty' : referer_is_config ? 'config' : 'another page' }
                     - Given referer:       #{h referer_uri.to_s}
                     - Expected base URI:   #{h base_uri.to_s}

--- a/spec/core/csrf_check_spec.rb
+++ b/spec/core/csrf_check_spec.rb
@@ -27,6 +27,115 @@ describe TDiary::TDiaryAuthorOnlyBase do
 			expect(described_class.csrf_referer_allowed?('http://attacker.example.org/editor.html', config_uri, regexp)).to be_falsey
 		end
 	end
+
+	describe '.csrf_origin_of' do
+		it 'normalizes scheme and host to lowercase without a default port' do
+			expect(described_class.csrf_origin_of('HTTP://WWW.Example.COM:80/d/update.rb')).to eq 'http://www.example.com'
+		end
+
+		it 'keeps a non-default port' do
+			expect(described_class.csrf_origin_of('https://www.example.com:8443/')).to eq 'https://www.example.com:8443'
+		end
+
+		it 'accepts a URI object' do
+			expect(described_class.csrf_origin_of(config_uri)).to eq 'http://www.example.com'
+		end
+
+		it 'returns nil for non-http URLs and garbage' do
+			expect(described_class.csrf_origin_of('')).to be_nil
+			expect(described_class.csrf_origin_of('ftp://example.com/')).to be_nil
+			expect(described_class.csrf_origin_of('http://[broken')).to be_nil
+		end
+	end
+
+	describe '.csrf_fetch_verdict' do
+		let(:allowed_origins) { ['http://www.example.com'] }
+
+		it 'is :same_origin when the Origin header matches' do
+			expect(described_class.csrf_fetch_verdict('http://www.example.com', nil, allowed_origins)).to eq :same_origin
+		end
+
+		it 'is :cross_site when the Origin header does not match' do
+			expect(described_class.csrf_fetch_verdict('http://attacker.example.org', nil, allowed_origins)).to eq :cross_site
+		end
+
+		it 'is :cross_site for an opaque Origin (null)' do
+			expect(described_class.csrf_fetch_verdict('null', nil, allowed_origins)).to eq :cross_site
+		end
+
+		it 'prefers Origin over Sec-Fetch-Site' do
+			expect(described_class.csrf_fetch_verdict('http://attacker.example.org', 'same-origin', allowed_origins)).to eq :cross_site
+		end
+
+		it 'is :same_origin for Sec-Fetch-Site: same-origin without Origin' do
+			expect(described_class.csrf_fetch_verdict(nil, 'same-origin', allowed_origins)).to eq :same_origin
+		end
+
+		it 'is :cross_site for Sec-Fetch-Site: cross-site and same-site' do
+			expect(described_class.csrf_fetch_verdict(nil, 'cross-site', allowed_origins)).to eq :cross_site
+			expect(described_class.csrf_fetch_verdict(nil, 'same-site', allowed_origins)).to eq :cross_site
+		end
+
+		it 'is :unknown when both headers are absent' do
+			expect(described_class.csrf_fetch_verdict(nil, nil, allowed_origins)).to eq :unknown
+		end
+
+		it 'is :unknown for Sec-Fetch-Site: none (user-initiated navigation)' do
+			expect(described_class.csrf_fetch_verdict(nil, 'none', allowed_origins)).to eq :unknown
+		end
+	end
+
+	describe '.csrf_provenance_ok?' do
+		let(:allowed_origins) { ['http://www.example.com'] }
+
+		def provenance_ok?(origin: nil, sec_fetch_site: nil, referer: '', regexp: '', check_referer: true)
+			described_class.csrf_provenance_ok?(origin, sec_fetch_site, referer, allowed_origins, config_uri, regexp, check_referer)
+		end
+
+		it 'passes on a matching Origin regardless of the referer' do
+			expect(provenance_ok?(origin: 'http://www.example.com')).to be_truthy
+		end
+
+		it 'passes on Sec-Fetch-Site: same-origin without Origin' do
+			expect(provenance_ok?(sec_fetch_site: 'same-origin')).to be_truthy
+		end
+
+		it 'rejects a cross-site Origin even when check_referer is disabled' do
+			expect(provenance_ok?(origin: 'http://attacker.example.org', check_referer: false)).to be_falsey
+		end
+
+		it 'rejects Sec-Fetch-Site: cross-site even when check_referer is disabled' do
+			expect(provenance_ok?(sec_fetch_site: 'cross-site', check_referer: false)).to be_falsey
+		end
+
+		it 'still honors the admin-configured referer regexp on a cross-site verdict' do
+			regexp = '\Ahttp://alt\.example\.org/'
+			expect(provenance_ok?(origin: 'http://alt.example.org', referer: 'http://alt.example.org/editor.html', regexp: regexp)).to be_truthy
+		end
+
+		context 'when Origin and Sec-Fetch-Site are both absent' do
+			it 'falls back to the referer check: update page referer passes' do
+				expect(provenance_ok?(referer: 'http://www.example.com/d/update.rb')).to be_truthy
+			end
+
+			it 'falls back to the referer check: another page is rejected' do
+				expect(provenance_ok?(referer: 'http://attacker.example.org/')).to be_falsey
+			end
+
+			it 'rejects an empty referer when check_referer is enabled' do
+				expect(provenance_ok?(referer: '')).to be_falsey
+			end
+
+			it 'tolerates an empty referer when check_referer is disabled' do
+				expect(provenance_ok?(referer: '', check_referer: false)).to be_truthy
+			end
+		end
+
+		it 'treats Sec-Fetch-Site: none like an absent signal' do
+			expect(provenance_ok?(sec_fetch_site: 'none', referer: '', check_referer: false)).to be_truthy
+			expect(provenance_ok?(sec_fetch_site: 'none', referer: '', check_referer: true)).to be_falsey
+		end
+	end
 end
 
 # Local Variables:

--- a/spec/core/csrf_check_spec.rb
+++ b/spec/core/csrf_check_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'uri'
+
+describe TDiary::TDiaryAuthorOnlyBase do
+	let(:config_uri) { URI.parse('http://www.example.com/d/') + 'update.rb' }
+
+	describe '.csrf_referer_allowed?' do
+		it 'accepts the update page itself' do
+			expect(described_class.csrf_referer_allowed?('http://www.example.com/d/update.rb', config_uri, '')).to be_truthy
+		end
+
+		it 'rejects another page on the same site' do
+			expect(described_class.csrf_referer_allowed?('http://www.example.com/d/index.rb', config_uri, '')).to be_falsey
+		end
+
+		it 'rejects a cross-site referer' do
+			expect(described_class.csrf_referer_allowed?('http://attacker.example.org/d/update.rb', config_uri, '')).to be_falsey
+		end
+
+		it 'accepts a referer matching the admin-configured regexp' do
+			regexp = '\Ahttp://alt\.example\.org/'
+			expect(described_class.csrf_referer_allowed?('http://alt.example.org/editor.html', config_uri, regexp)).to be_truthy
+		end
+
+		it 'rejects a referer not matching the admin-configured regexp' do
+			regexp = '\Ahttp://alt\.example\.org/'
+			expect(described_class.csrf_referer_allowed?('http://attacker.example.org/editor.html', config_uri, regexp)).to be_falsey
+		end
+	end
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:
+# vim: ts=3


### PR DESCRIPTION
`csrf_check` now validates update requests with browser fetch metadata first. A request passes when `Origin` matches one of the site's own origins (conf `base_url`, the update page URI, or the request's own origin) or when `Sec-Fetch-Site` is `same-origin`. When either header proves the request cross-site it is rejected, though a referer matching `csrf_protection_allowed_referer_regexp_for_update` is still accepted. The legacy `Referer` check runs only when neither header is present, so clients sending none of the three headers (curl, old browsers, rack-test) keep the exact semantics of the existing `csrf_protection_method` bits. The acceptance suite passing unchanged exercises that fallback path. No conf option changes meaning and none is added. Together with the `SameSite=Lax` cookie from #1360 and the `Referrer-Policy` default from #1368 this forms layered CSRF defense. This PR is intentionally standalone so it can be reverted alone if updates lock out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
