### PR TITLE
Make the assets base URL configurable and retire in-repo RackCGI checks

### DIFF
--- a/lib/tdiary/core_ext.rb
+++ b/lib/tdiary/core_ext.rb
@@ -15,6 +15,14 @@ module TDiary
 			false
 		end
 
+		# true when the endpoint runs behind a web server (CGI/FCGI hosting,
+		# which sets tdiary.static_assets in the env) that serves the js/ and
+		# theme/ directories itself; false on the Rack path, where
+		# TDiary::Application serves them under assets/
+		def static_assets?
+			env['tdiary.static_assets'] ? true : false
+		end
+
 		# params with CGI semantics, unlike Rack::Request#params: POST reads
 		# only the body, every value is an Array, unknown keys yield [],
 		# duplicated keys collect all values, broken UTF-8 input is retried

--- a/lib/tdiary/core_ext.rb
+++ b/lib/tdiary/core_ext.rb
@@ -196,7 +196,8 @@ end
 require 'tdiary/cgi_compat'
 
 # the @cgi facade for Rack-hosted requests. Kept as a toplevel constant
-# because plugins switch behaviour with @cgi.is_a?(RackCGI).
+# only for third-party plugins that switch behaviour with
+# @cgi.is_a?(RackCGI); in-repo code reads static_assets? instead.
 class RackCGI < TDiary::CGICompat; end
 
 # Local Variables:

--- a/lib/tdiary/plugin/00default.rb
+++ b/lib/tdiary/plugin/00default.rb
@@ -372,8 +372,18 @@ def script_tag_query_string
 	"?#{TDIARY_VERSION}#{Time::now.strftime('%Y%m%d')}"
 end
 
+# base URL the static assets are served from, when specified in
+# tdiary.conf: @options['assets_url'] = 'https://assets.example.org/tdiary'
+# It expects the merged layout the Rack assets/ mount serves (js files and
+# theme directories under one root) and wins over the hosting default on
+# every path (Rack, CGI and FCGI).
+def configured_assets_url
+	url = @conf['assets_url']
+	url && !url.empty? ? url.chomp('/') : nil
+end
+
 def js_url
-	@cgi.is_a?(RackCGI) ? 'assets' : 'js'
+	configured_assets_url || (@cgi.static_assets? ? 'js' : 'assets')
 end
 
 def script_tag
@@ -396,7 +406,7 @@ def script_tag
 end
 
 def theme_url
-	@cgi.is_a?(RackCGI) ? 'assets' : 'theme'
+	configured_assets_url || (@cgi.static_assets? ? 'theme' : 'assets')
 end
 
 def css_tag

--- a/lib/tdiary/request.rb
+++ b/lib/tdiary/request.rb
@@ -5,8 +5,9 @@ module TDiary
 
 		# the @cgi object handed to plugins: a facade over this request.
 		# Endpoints behind a web server (CGI/FCGI) set tdiary.static_assets in
-		# the env to get the base CGICompat, so @cgi.is_a?(RackCGI) is false and
-		# plugins keep the static js/theme URLs served by the web server.
+		# the env to get the base CGICompat. The RackCGI/CGICompat split only
+		# serves third-party plugins that check @cgi.is_a?(RackCGI); in-repo
+		# code reads the flag through RequestExtension#static_assets?.
 		def cgi_compat
 			@cgi_compat ||=
 				if env['tdiary.static_assets']

--- a/misc/plugin/image.rb
+++ b/misc/plugin/image.rb
@@ -101,7 +101,7 @@ end
 #
 # initialize
 #
-@image_dir = (@options && @options['image.dir']) || File.join(TDiary.server_root, @cgi.is_a?(RackCGI) ? 'public/images' : 'images')
+@image_dir = (@options && @options['image.dir']) || File.join(TDiary.server_root, @cgi.static_assets? ? 'images' : 'public/images')
 @image_dir.chop! if /\/$/ =~ @image_dir
 FileUtils.mkdir_p @image_dir unless File.exist?(@image_dir)
 

--- a/misc/plugin/makerss.rb
+++ b/misc/plugin/makerss.rb
@@ -177,10 +177,10 @@ class MakeRssFull
 	end
 
 	def document_root
-		if @cgi.is_a?(RackCGI)
-			File.join(TDiary.server_root, 'public')
-		else
+		if @cgi.static_assets?
 			TDiary.server_root
+		else
+			File.join(TDiary.server_root, 'public')
 		end
 	end
 end

--- a/spec/acceptance/view_diary_spec.rb
+++ b/spec/acceptance/view_diary_spec.rb
@@ -22,6 +22,21 @@ feature '日記を読む' do
 		expect(local_script_srcs).to all( start_with 'assets/' )
 	end
 
+	scenario 'confのassets_url指定時はCSSとJavaScriptがそのURLから配信される', :exclude_webrick do
+		assets_url = 'https://assets.example.org/tdiary/'
+		conf_path = File.expand_path('../../tmp/data/tdiary.conf', __dir__)
+		File.write(conf_path, "options2 = { 'assets_url' => '#{assets_url}' }\n", mode: 'a')
+
+		visit '/'
+		stylesheet_hrefs = page.all('link[rel=stylesheet]', visible: false).map {|link| link[:href] }
+		expect(stylesheet_hrefs).not_to be_empty
+		expect(stylesheet_hrefs).to all( start_with assets_url )
+
+		script_srcs = page.all('script[src]', visible: false).map {|script| script[:src] }
+		expect(script_srcs.select {|src| src.start_with?(assets_url) }).not_to be_empty
+		expect(script_srcs.grep(%r{\A(assets|js)/})).to be_empty
+	end
+
 	scenario '月またぎの日記の表示' do
 		append_default_diary('20100430')
 		append_default_diary('20100501')

--- a/spec/core/cgi_endpoint_smoke_spec.rb
+++ b/spec/core/cgi_endpoint_smoke_spec.rb
@@ -45,6 +45,44 @@ describe 'index.rb as a plain CGI program' do
 	end
 end
 
+# Locks the conf priority: an explicit assets_url wins over the static
+# js/theme URLs of CGI hosting.
+describe 'index.rb as a plain CGI program with assets_url configured' do
+	before(:all) do
+		repo_root = File.expand_path('../../..', __FILE__)
+		@workdir = Dir.mktmpdir('tdiary-cgi-smoke')
+		data_dir = File.join(@workdir, 'tmp/data')
+		FileUtils.mkdir_p data_dir
+		FileUtils.cp File.join(repo_root, 'spec/fixtures/tdiary.conf.webrick'), File.join(@workdir, 'tdiary.conf')
+		File.write File.join(@workdir, 'tdiary.conf'), "\n@options['assets_url'] = 'https://assets.example.org/tdiary/'\n", mode: 'a'
+		FileUtils.cp File.join(repo_root, 'spec/fixtures/just_installed.conf'), File.join(data_dir, 'tdiary.conf')
+
+		env = {
+			'GATEWAY_INTERFACE' => 'CGI/1.1',
+			'REQUEST_METHOD' => 'GET',
+			'QUERY_STRING' => '',
+			'SCRIPT_NAME' => '/index.rb',
+			'SERVER_NAME' => 'www.example.com',
+			'SERVER_PORT' => '80',
+			'HTTP_HOST' => 'www.example.com',
+			'SERVER_PROTOCOL' => 'HTTP/1.1',
+			'REMOTE_ADDR' => '127.0.0.1'
+		}
+		stdout, @stderr, @process_status = Open3.capture3(env, RbConfig.ruby, File.join(repo_root, 'index.rb'), chdir: @workdir)
+		@head, _separator, @body = stdout.partition(/\r?\n\r?\n/)
+	end
+
+	after(:all) do
+		FileUtils.remove_entry @workdir
+	end
+
+	it 'links css and scripts under the configured URL' do
+		expect(@head).to match(/^Status: 200/), -> { "head: #{@head.inspect}\nstderr: #{@stderr}" }
+		expect(@body).to match(%r|<link rel="stylesheet" href="https://assets\.example\.org/tdiary/base\.css"|)
+		expect(@body).to match(%r|<script src="https://assets\.example\.org/tdiary/00default\.js|)
+	end
+end
+
 # Locks the POST path and the expansion of Array header values (Set-Cookie)
 # into one header line each.
 describe 'index.rb comment POST as a plain CGI program' do

--- a/spec/core/request_spec.rb
+++ b/spec/core/request_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 require 'rack'
 
 describe TDiary::Request do
-	describe '#cgi_compat' do
-		def build_request(env = {})
-			rack_env = Rack::MockRequest.env_for('http://www.example.com/')
-			rack_env.merge!(env)
-			TDiary::Request.new(rack_env)
-		end
+	def build_request(env = {})
+		rack_env = Rack::MockRequest.env_for('http://www.example.com/')
+		rack_env.merge!(env)
+		TDiary::Request.new(rack_env)
+	end
 
+	describe '#cgi_compat' do
 		it 'returns a RackCGI facade on the Rack path' do
 			expect(build_request.cgi_compat).to be_a(RackCGI)
 		end
@@ -22,6 +22,21 @@ describe TDiary::Request do
 		it 'is memoized on the request' do
 			request = build_request('tdiary.static_assets' => true)
 			expect(request.cgi_compat).to equal(request.cgi_compat)
+		end
+	end
+
+	describe '#static_assets?' do
+		it 'is false on the Rack path' do
+			expect(build_request.static_assets?).to be false
+		end
+
+		it 'is true when tdiary.static_assets is set' do
+			expect(build_request('tdiary.static_assets' => true).static_assets?).to be true
+		end
+
+		it 'is visible through the cgi_compat facade' do
+			expect(build_request.cgi_compat.static_assets?).to be false
+			expect(build_request('tdiary.static_assets' => true).cgi_compat.static_assets?).to be true
 		end
 	end
 end

--- a/tdiary.conf.sample
+++ b/tdiary.conf.sample
@@ -75,6 +75,14 @@
 #   必要です。blog-category プラグイン利用時は自動的に無効になります。
 #@options['plugin.cache'] = true
 
+# 静的アセットの配信元URL【オプション】
+#   テーマやJavaScriptなどの静的ファイルを、CDNや別ホストなど任意のURLから
+#   配信する場合に指定します。指定すると、Rack・CGI・FCGIのどの実行形態でも
+#   このURLを元にテーマやJavaScriptのURLを生成します。配信元には、Rackアプ
+#   リのassets配下と同じ構成(jsディレクトリとthemeディレクトリの内容をひと
+#   つのディレクトリにまとめた構成)でファイルを配置してください。
+#@options['assets_url'] = 'https://assets.example.org/tdiary'
+
 # プラグインに渡すオプション【オプション】
 #   プラグインによっては、tdiary.conf経由でオプションを渡すことで挙動を
 #   変更できるものがあります。@optionsはそのオプションを指定する時に使う

--- a/tdiary.conf.sample-en
+++ b/tdiary.conf.sample-en
@@ -62,6 +62,14 @@
 #   any directory for cache files by this variable.
 #@cache_path = 'path of cache files'
 
+# base URL of static assets. (optional)
+#   Set this to serve theme and JavaScript files from another URL, such
+#   as a CDN. When set, every hosting mode (Rack, CGI and FCGI) builds
+#   theme and JavaScript URLs from it. The serving location must use the
+#   same merged layout as the assets/ mount of the Rack application (the
+#   contents of the js and theme directories under one root).
+#@options['assets_url'] = 'https://assets.example.org/tdiary'
+
 # options for plugins. (optional)
 #   Some plugins can receive options from tdiary.conf.
 #     ex: a option "foo" of plugin "sample".


### PR DESCRIPTION
Closes #790.

Static asset URLs could not be pointed at a CDN or another host: `js_url` and `theme_url` were hard-wired to the hosting mode by `@cgi.is_a?(RackCGI)`. Setting `@options['assets_url']` in `tdiary.conf` now serves theme and JavaScript files from that URL on every path (Rack, CGI and FCGI). The serving location uses the same merged layout as the Rack `assets/` mount.

Priority is the explicit conf value first, then the previous default chosen by the `tdiary.static_assets` env flag, so generated URLs are unchanged when the option is unset. The existing Rack assets acceptance spec and the CGI smoke spec pass unmodified; new specs cover the configured URL on both paths.

The four in-repo `@cgi.is_a?(RackCGI)` checks are replaced by `RequestExtension#static_assets?`. The `RackCGI` constant and the facade class selection remain for third-party plugin compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
