### PR TITLE
Accept semicolon-separated query strings again

### DIFF
--- a/lib/tdiary/core_ext.rb
+++ b/lib/tdiary/core_ext.rb
@@ -104,11 +104,13 @@ module TDiary
 						self.POST
 					else
 						# Rack's nested query parser behind Rack::Request#POST keeps
-						# only the last of duplicated keys; CGI collects all of them
-						::Rack::Utils.parse_query( read_raw_body )
+						# only the last of duplicated keys; CGI collects all of them.
+						# CGI also splits on ';' as well as '&', and tDiary's own edit
+						# links (00default.rb, edit_today.rb) still use ';'
+						::Rack::Utils.parse_query( read_raw_body, '&;' )
 					end
 				else
-					::Rack::Utils.parse_query( env['QUERY_STRING'].to_s )
+					::Rack::Utils.parse_query( env['QUERY_STRING'].to_s, '&;' )
 				end
 
 			params = {}

--- a/lib/tdiary/request.rb
+++ b/lib/tdiary/request.rb
@@ -16,6 +16,15 @@ module TDiary
 					::RackCGI.new( self )
 				end
 		end
+
+	private
+
+		# CGI splits the query string on ';' as well as '&', and tDiary's own
+		# edit links (00default.rb, edit_today.rb) still use ';'; Rack 3
+		# dropped the ';' separator, so restore it for Rack::Request#params
+		def parse_query( qs, d = '&' )
+			super( qs, '&;' )
+		end
 	end
 end
 

--- a/spec/core/request_spec.rb
+++ b/spec/core/request_spec.rb
@@ -25,6 +25,15 @@ describe TDiary::Request do
 		end
 	end
 
+	describe '#params' do
+		# the update dispatcher branches on request.params, and
+		# 00default.rb generates ';'-separated edit links
+		it 'splits the query string on semicolons like CGI' do
+			request = build_request('QUERY_STRING' => 'edit=true;year=2026;month=8;day=9')
+			expect(request.params).to eq({ 'edit' => 'true', 'year' => '2026', 'month' => '8', 'day' => '9' })
+		end
+	end
+
 	describe '#static_assets?' do
 		it 'is false on the Rack path' do
 			expect(build_request.static_assets?).to be false

--- a/spec/support/cgi_compat_shared_examples.rb
+++ b/spec/support/cgi_compat_shared_examples.rb
@@ -30,6 +30,18 @@ RSpec.shared_examples 'CGI compatible request facade' do
 			end
 		end
 
+		# 00default.rb and edit_today.rb generate ';'-separated edit links
+		context 'with semicolon separated GET query string' do
+			let(:cgi) { build_cgi({ 'REQUEST_METHOD' => 'GET', 'QUERY_STRING' => 'edit=true;year=2026;month=8;day=9' }) }
+
+			it 'splits parameters on semicolons like CGI' do
+				expect(cgi.params['edit']).to eq ['true']
+				expect(cgi.params['year']).to eq ['2026']
+				expect(cgi.params['month']).to eq ['8']
+				expect(cgi.params['day']).to eq ['9']
+			end
+		end
+
 		context 'with POST body' do
 			let(:cgi) {
 				build_cgi(


### PR DESCRIPTION
tDiary 5.5.0 replaced CGI-based parameter parsing with Rack, which splits query strings on `&` only. `00default.rb` and `edit_today.rb` still generate `;`-separated edit links like `update.rb?edit=true;year=2026;month=8;day=9`, so `year` was never parsed, `TDiaryAdmin` raised `bad date` and the update screen silently fell back to today's form. This restores the `;` separator in both `cgi_params` and `Rack::Request#params`.

Reported in https://github.com/tdiary/tdiary-core/discussions/1371.
